### PR TITLE
fix for #305

### DIFF
--- a/nlmod/read/ahn.py
+++ b/nlmod/read/ahn.py
@@ -75,46 +75,18 @@ def get_ahn(ds=None, identifier="AHN4_DTM_5m", method="average", extent=None):
     return ds_out
 
 
-def _infer_url(identifier=None):
-    """infer the url from the identifier.
-
-    Parameters
-    ----------
-    identifier : str, optional
-        identifier of the ahn type. The default is None.
-
-    Raises
-    ------
-    ValueError
-        unknown identifier.
-
-    Returns
-    -------
-    url : str
-        ahn url corresponding to identifier.
-    """
-
-    # infer url from identifier
-    if "ahn3" in identifier:
-        url = "https://service.pdok.nl/rws/ahn3/wcs/v1_0?service=wcs"
-    else:
-        raise ValueError(f"unknown identifier -> {identifier}")
-
-    return url
-
-
 def get_ahn_at_point(
     x,
     y,
     buffer=0.75,
     return_da=False,
     return_mean=False,
-    identifier="ahn3_05m_dtm",
+    identifier="dsm_05m",
     res=0.5,
     **kwargs,
 ):
     extent = [x - buffer, x + buffer, y - buffer, y + buffer]
-    ahn = get_ahn_from_wcs(extent, identifier=identifier, res=res, **kwargs)
+    ahn = get_latest_ahn_from_wcs(extent, identifier=identifier, res=res, **kwargs)
     if return_da:
         # return a DataArray
         return ahn
@@ -126,13 +98,13 @@ def get_ahn_at_point(
         return ahn.data[int((ahn.shape[0] - 1) / 2), int((ahn.shape[1] - 1) / 2)]
 
 
-def get_ahn_from_wcs(
+@cache.cache_netcdf
+def get_latest_ahn_from_wcs(
     extent=None,
-    identifier="ahn3_5m_dtm",
-    url=None,
+    identifier="dsm_05m",
     res=None,
     version="1.0.0",
-    fmt="GEOTIFF_FLOAT32",
+    fmt="image/tiff",
     crs="EPSG:28992",
     maxsize=2000,
 ):
@@ -143,18 +115,13 @@ def get_ahn_from_wcs(
         extent. The default is None.
     identifier : str, optional
         Possible values for identifier are:
-            'ahn3_05m_dsm'
-            'ahn3_05m_dtm'
-            'ahn3_5m_dsm'
-            'ahn3_5m_dtm'
-        The default is 'ahn3_5m_dtm'.
-        the identifier also contains resolution and type info:
-        - 5m or 05m is a resolution of 5x5 or 0.5x0.5 meter.
+            'dsm_05m'
+            'dtm_05m'
+        The default is 'dsm_05m'.
+        the identifier contains resolution and type info:
         - 'dtm' is only surface level (maaiveld), 'dsm' has other surfaces
-        such as building.
-    url : str or None, optional
-        possible values None, 'ahn2' and 'ahn3'. If None the url is inferred
-        from the identifier. The default is None.
+        such as buildings.
+        - 5m or 05m is a resolution of 5x5 or 0.5x0.5 meter.
     res : float, optional
         resolution of ahn raster. If None the resolution is inferred from the
         identifier. The default is None.
@@ -175,19 +142,22 @@ def get_ahn_from_wcs(
         DataArray (if as_data_array is True) or Rasterio MemoryFile of the AHN
     """
 
+    url = "https://service.pdok.nl/rws/ahn/wcs/v1_0?SERVICE=WCS&request=GetCapabilities"
+
     if isinstance(extent, xr.DataArray):
         extent = tuple(extent.values)
-
-    # get url
-    if url is None:
-        url = _infer_url(identifier)
 
     # check resolution
     if res is None:
         if "05m" in identifier.split("_")[1]:
             res = 0.5
         elif "5m" in identifier.split("_")[1]:
-            res = 5.0
+            logger.warning(
+                "5 meter resolution is no langer available via wcs, try nlmod.read.get_ahn4 ot obtain ahn with a 5m resolution. for more info see: https://www.pdok.nl/-/nieuwe-versie-ahn-beschikbaar-via-pdok"
+            )
+            raise ValueError(
+                "5 meter resolution no longer available via wcs use nlmod.read.get_ahn4"
+            )
         else:
             raise ValueError("could not infer resolution from identifier")
 

--- a/nlmod/read/ahn.py
+++ b/nlmod/read/ahn.py
@@ -153,7 +153,10 @@ def get_latest_ahn_from_wcs(
             res = 0.5
         elif "5m" in identifier.split("_")[1]:
             logger.warning(
-                "5 meter resolution is no langer available via wcs, try nlmod.read.get_ahn4 ot obtain ahn with a 5m resolution. for more info see: https://www.pdok.nl/-/nieuwe-versie-ahn-beschikbaar-via-pdok"
+                "5 meter resolution is no langer available via wcs, try "
+                "nlmod.read.get_ahn4 ot obtain ahn with a 5m resolution. for "
+                "more info see: "
+                "https://www.pdok.nl/-/nieuwe-versie-ahn-beschikbaar-via-pdok"
             )
             raise ValueError(
                 "5 meter resolution no longer available via wcs use nlmod.read.get_ahn4"

--- a/nlmod/read/waterboard.py
+++ b/nlmod/read/waterboard.py
@@ -202,7 +202,17 @@ def get_configuration():
         "level_areas": {
             "url": "https://kaarten.hhnk.nl/arcgis/rest/services/ws/ws_peilgebieden_vigerend/MapServer",
             "layer": 4,
-            # "table": 6,
+            "table": {
+                "id": 6,
+                "SOORFSTREEFPEIL": {
+                    901: "STREEFPEIL_JAARROND",  # vast peilbeheer
+                    902: "STREEFPEIL_WINTER",
+                    903: "STREEFPEIL_ZOMER",
+                    904: "STREEFPEIL_JAARROND",  # dynamisch peilbeheer
+                    905: "ONDERGRENS_JAARROND",
+                    906: "BOVENGRENS_JAARROND",
+                },
+            },
             "summer_stage": [
                 "ZOMER",
                 "STREEFPEIL_ZOMER",

--- a/nlmod/read/waterboard.py
+++ b/nlmod/read/waterboard.py
@@ -202,6 +202,7 @@ def get_configuration():
         "level_areas": {
             "url": "https://kaarten.hhnk.nl/arcgis/rest/services/ws/ws_peilgebieden_vigerend/MapServer",
             "layer": 4,
+            # "table": 6,
             "summer_stage": [
                 "ZOMER",
                 "STREEFPEIL_ZOMER",
@@ -524,6 +525,7 @@ def get_data(wb, data_kind, extent=None, max_record_count=None, config=None, **k
         config = get_configuration()
     # some default values
     layer = 0
+    table = None
     index = "CODE"
     server_kind = "arcrest"
     f = "geojson"
@@ -536,6 +538,8 @@ def get_data(wb, data_kind, extent=None, max_record_count=None, config=None, **k
     url = conf["url"]
     if "layer" in conf:
         layer = conf["layer"]
+    if "table" in conf:
+        table = conf["table"]
     if "index" in conf:
         index = conf["index"]
     if "server_kind" in conf:
@@ -551,8 +555,10 @@ def get_data(wb, data_kind, extent=None, max_record_count=None, config=None, **k
             extent,
             f=f,
             max_record_count=max_record_count,
+            table=table,
             **kwargs,
         )
+
     elif server_kind == "wfs":
         gdf = webservices.wfs(
             url, layer, extent, max_record_count=max_record_count, **kwargs

--- a/nlmod/read/waterboard.py
+++ b/nlmod/read/waterboard.py
@@ -204,7 +204,7 @@ def get_configuration():
             "layer": 4,
             "table": {
                 "id": 6,
-                "SOORFSTREEFPEIL": {
+                "SOORTSTREEFPEIL": {
                     901: "STREEFPEIL_JAARROND",  # vast peilbeheer
                     902: "STREEFPEIL_WINTER",
                     903: "STREEFPEIL_ZOMER",

--- a/nlmod/read/waterboard.py
+++ b/nlmod/read/waterboard.py
@@ -201,6 +201,7 @@ def get_configuration():
         },
         "level_areas": {
             "url": "https://kaarten.hhnk.nl/arcgis/rest/services/ws/ws_peilgebieden_vigerend/MapServer",
+            "layer": 4,
             "summer_stage": [
                 "ZOMER",
                 "STREEFPEIL_ZOMER",

--- a/nlmod/read/webservices.py
+++ b/nlmod/read/webservices.py
@@ -161,10 +161,14 @@ def arcrest(
                 # add peilen to gdf
                 for col, convert_dic in table.items():
                     df[col].replace(convert_dic, inplace=True)
-                df.set_index(col, inplace=True)
-                for oid in gdf["OBJECTID"]:
-                    insert_s = df.loc[df["PEILGEBIEDVIGERENDID"] == oid, "WATERHOOGTE"]
-                    gdf.loc[gdf["OBJECTID"] == oid, insert_s.index] = insert_s.values
+                    df.set_index(col, inplace=True)
+                    for oid in gdf["OBJECTID"]:
+                        insert_s = df.loc[
+                            df["PEILGEBIEDVIGERENDID"] == oid, "WATERHOOGTE"
+                        ]
+                        gdf.loc[
+                            gdf["OBJECTID"] == oid, insert_s.index
+                        ] = insert_s.values
 
     return gdf
 

--- a/nlmod/read/webservices.py
+++ b/nlmod/read/webservices.py
@@ -27,6 +27,7 @@ def arcrest(
     f="geojson",
     max_record_count=None,
     timeout=120,
+    table=None,
     **kwargs,
 ):
     """Download data from an arcgis rest FeatureServer.
@@ -47,6 +48,8 @@ def arcrest(
         maximum number of records for request.
     timeout : int, optional
         timeout time of request. Default is 120.
+    table : int, optional
+        can be used to link a layer to a table, not yet implemented.
 
     Note
     ----
@@ -146,6 +149,12 @@ def arcrest(
             gdf = gpd.GeoDataFrame()
         else:
             gdf = gpd.GeoDataFrame.from_features(features, crs=sr)
+            if table is not None:
+                raise NotImplementedError("work in progress")
+                url_query = f"{url}/{table}/query"
+                pgbids = ",".join([str(v) for v in gdf["OBJECTID"].values])
+                params["where"] = f"PEILGEBIEDVIGERENDID IN ({pgbids})"
+                data = _get_data(url_query, params, timeout=timeout)
     return gdf
 
 

--- a/nlmod/read/webservices.py
+++ b/nlmod/read/webservices.py
@@ -31,6 +31,23 @@ def arcrest(
 ):
     """Download data from an arcgis rest FeatureServer.
 
+    Parameters
+    ----------
+    url : str
+        arcrest url.
+    layer : str
+        layer
+    extent : list, tuple or np.array
+        extent
+    sr : int, optional
+        coördinate reference system. The default is 28992 (RD).
+    f : str, optional
+        output format. Default is geojson
+    max_record_count : int, optional
+        maximum number of records for request.
+    timeout : int, optional
+        timeout time of request. Default is 120.
+
     Note
     ----
     The sr argument is left as 28992 and not converted to the EPSG_28992 constant
@@ -133,6 +150,22 @@ def arcrest(
 
 
 def _get_data(url, params, timeout=120, **kwargs):
+    """get data using a request
+
+    Parameters
+    ----------
+    url : str
+        url
+    params : dict
+        request parameters
+    timeout : int, optional
+        timeout time of request. Default is 120.
+
+    Returns
+    -------
+    data
+
+    """
     r = requests.get(url, params=params, timeout=timeout, **kwargs)
     if not r.ok:
         raise (HTTPError(f"Request not successful: {r.url}"))
@@ -154,7 +187,36 @@ def wfs(
     driver="GML",
     timeout=120,
 ):
-    """Download data from a wfs server."""
+    """Download data from a wfs server and convert to Geodataframe.
+
+    Parameters
+    ----------
+    url : str
+        webservice url.
+    layer : str
+        layer
+    extent : list, tuple or np.array
+        extent
+    version : str
+        version of wcs service, options are '1.0.0' and '2.0.1'.
+    paged : bool, optional
+        , by default True
+    max_record_count : int, optional
+        maximum number of records for request.
+    driver : str, optional
+        driver used to decode data with geopandas, by default "GML"
+    timeout : int, optional
+        timeout time of request. Default is 120.
+
+    Returns
+    -------
+    GeoDataFrame
+
+    Raises
+    ------
+    Exception
+        _description_
+    """
     params = {"version": version, "request": "GetFeature"}
     if version == "2.0.0":
         params["typeNames"] = layer
@@ -255,12 +317,12 @@ def wcs(
 
     Parameters
     ----------
+    url : str
+        webservice url.
     extent : list, tuple or np.array
         extent
     res : float, optional
         resolution of wcs raster
-    url : str
-        webservice url.
     identifier : str
         identifier.
     version : str
@@ -269,6 +331,10 @@ def wcs(
         geotif format
     crs : str, optional
         coördinate reference system
+    maxsize : int, optional
+        maximum pixel size of request. If the combination of extent and resolution
+        exceeds the maxsize the extent is split into smaller segments and
+        downloaded seperately. The default is 2000.
 
     Raises
     ------
@@ -341,14 +407,24 @@ def _split_wcs_extent(
     ----------
     extent : list, tuple or np.array
         extent
-    res : float
-        The resolution of the requested output-data
     x_segments : int
         number of tiles on the x axis
     y_segments : int
         number of tiles on the y axis
     maxsize : int or float
         maximum widht or height of wcs tile
+    res : float
+        The resolution of the requested output-data
+    url : str
+        webservice url.
+    identifier : str
+        identifier.
+    version : str
+        version of wcs service, options are '1.0.0' and '2.0.1'.
+    fmt : str, optional
+        geotif format
+    crs : str, optional
+        coördinate reference system
 
     Returns
     -------

--- a/nlmod/read/webservices.py
+++ b/nlmod/read/webservices.py
@@ -158,9 +158,10 @@ def arcrest(
                 df = pd.DataFrame(
                     [feature["attributes"] for feature in data["features"]]
                 )
+                # add peilen to gdf
                 for col, convert_dic in table.items():
-                    df["SOORTSTREEFPEIL"].replace(convert_dic, inplace=True)
-                df.set_index("SOORTSTREEFPEIL", inplace=True)
+                    df[col].replace(convert_dic, inplace=True)
+                df.set_index(col, inplace=True)
                 for oid in gdf["OBJECTID"]:
                     insert_s = df.loc[df["PEILGEBIEDVIGERENDID"] == oid, "WATERHOOGTE"]
                     gdf.loc[gdf["OBJECTID"] == oid, insert_s.index] = insert_s.values

--- a/tests/test_005_external_data.py
+++ b/tests/test_005_external_data.py
@@ -43,15 +43,15 @@ def test_get_recharge_not_available():
 
 
 def test_ahn_within_extent():
-    extent = [95000.0, 105000.0, 494000.0, 500000.0]
-    da = nlmod.read.ahn.get_ahn_from_wcs(extent)
+    extent = [104000.0, 105000.0, 494000.0, 494600.0]
+    da = nlmod.read.ahn.get_latest_ahn_from_wcs(extent)
 
     assert not da.isnull().all(), "AHN only has nan values"
 
 
 def test_ahn_split_extent():
-    extent = [95000.0, 105000.0, 494000.0, 500000.0]
-    da = nlmod.read.ahn.get_ahn_from_wcs(extent, maxsize=1000)
+    extent = [104000.0, 105000.0, 494000.0, 494600.0]
+    da = nlmod.read.ahn.get_latest_ahn_from_wcs(extent, maxsize=1000)
 
     assert not da.isnull().all(), "AHN only has nan values"
 


### PR DESCRIPTION
De oude wcs url om AHN3 binnen te halen is niet meer beschikbaar. Er is nu één wcs url waarmee telkens het laatste ahn wordt opgehaald. Dat is nu AHN4 maar in de toekomst wordt dit automatisch AHN5. Ook is het niet meer mogelijk om met de nieuwe wcs url maaivelddata op een resolutie van 5 meter op te halen (alleen 0,5 meter wordt ondersteund).

Ik heb de `get_ahn3` functie voor de volledigheid geupdate hoewel ik denk dat het gebruik ervan beperkt zal zijn. De `get_ahn` functie maakt al gebruik van de tiles en niet van de wcs. Hier veranderd dus niet zoveel.