### PR TITLE
Add support for NHI GWO database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,17 @@ jobs:
 
       - name: Run notebooks
         if: ${{ github.event_name == 'push' }}
+        env:
+            NHI_GWO_USERNAME: ${{ secrets.NHI_GWO_USERNAME}}
+            NHI_GWO_PASSWORD: ${{ secrets.NHI_GWO_PASSWORD}}
         run: |
           py.test ./tests -m "not notebooks"
 
       - name: Run tests only
         if: ${{ github.event_name == 'pull_request' }}
+        env:
+            NHI_GWO_USERNAME: ${{ secrets.NHI_GWO_USERNAME}}
+            NHI_GWO_PASSWORD: ${{ secrets.NHI_GWO_PASSWORD}}
         run: |
           py.test ./tests -m "not notebooks"
 

--- a/nlmod/read/nhi.py
+++ b/nlmod/read/nhi.py
@@ -187,6 +187,7 @@ def get_gwo_wells(
     organisation=None,
     status=None,
     well_index="Name",
+    timeout=120,
     **kwargs,
 ):
     """
@@ -216,6 +217,8 @@ def get_gwo_wells(
     well_index : str, tuple or list, optional
         The column(s) in the resulting GeoDataFrame that is/are used as the index of
         this GeoDataFrame. The default is "Name".
+    timeout : int, optional
+        The timeout time of requests to the database. The default is 120.
     **kwargs : dict
         Kwargs are passed as additional parameters in the request to the database. For
         available parameters see https://gwo.nhi.nu/api/v1/download/.
@@ -241,7 +244,7 @@ def get_gwo_wells(
             params["well__site"] = well_site
         params.update(kwargs)
 
-        r = requests.get(url, auth=(username, password), params=params)
+        r = requests.get(url, auth=(username, password), params=params, timeout=timeout)
         content = r.content.decode("utf-8")
         df = pd.read_csv(io.StringIO(content), skiprows=list(range(8)) + [9], sep=";")
         properties.append(df)
@@ -265,6 +268,7 @@ def get_gwo_measurements(
     well_site=None,
     well_index="Name",
     measurement_index=("Name", "DateTime"),
+    timeout=120,
     **kwargs,
 ):
     """
@@ -291,6 +295,8 @@ def get_gwo_measurements(
     measurement_index :  str, tuple or list, optional, optional
         The column(s) in the resulting measurement-DataFrame that is/are used as the
         index of this DataFrame. The default is ("Name", "DateTime").
+    timeout : int, optional
+        The timeout time of requests to the database. The default is 120.
     **kwargs : dict
         Kwargs are passed as additional parameters in the request to the database. For
         available parameters see https://gwo.nhi.nu/api/v1/download/.
@@ -316,7 +322,7 @@ def get_gwo_measurements(
         if well_site is not None:
             params["filter__well__site"] = well_site
         params.update(kwargs)
-        r = requests.get(url, auth=(username, password), params=params)
+        r = requests.get(url, auth=(username, password), params=params, timeout=timeout)
 
         content = r.content.decode("utf-8")
         lines = content.split("\n")

--- a/nlmod/read/nhi.py
+++ b/nlmod/read/nhi.py
@@ -250,7 +250,7 @@ def get_gwo_wells(
         if len(content) == 0:
             if page == 1:
                 msg = "No extraction wells found for the requested parameters"
-                raise Exception(msg)
+                raise ValueError(msg)
             else:
                 # the number of wells is exactly a multiple of n_well_filters
                 page = None
@@ -342,7 +342,7 @@ def get_gwo_measurements(
         if len(content) == 0:
             if page == 1:
                 msg = "No extraction rates found for the requested parameters"
-                raise (Exception(msg))
+                raise (ValueError(msg))
             else:
                 # the number of measurements is exactly a multiple of n_measurements
                 page = None

--- a/nlmod/read/nhi.py
+++ b/nlmod/read/nhi.py
@@ -1,8 +1,12 @@
 import logging
 import os
+import io
+import requests
 
 import numpy as np
-import requests
+import pandas as pd
+import geopandas as gpd
+
 import rioxarray
 
 from ..dims.resample import structured_da_to_ds
@@ -173,3 +177,183 @@ def add_buisdrainage(
     ds[depth_var] = ds[depth_var] / 100.0
 
     return ds
+
+
+def get_gwo_wells(
+    username,
+    password,
+    n_well_filters=1_000,
+    well_site=None,
+    organisation=None,
+    status=None,
+    well_index="Name",
+    **kwargs,
+):
+    """
+    Get metadata of extraction wells from the NHI GWO database
+
+    Parameters
+    ----------
+    username : str
+        The username of the NHI GWO database. To retreive a username and password visit
+        https://gwo.nhi.nu/register/.
+    password : TYPE
+        The password of the NHI GWO database. To retreive a username and password visit
+        https://gwo.nhi.nu/register/.
+    n_well_filters : int, optional
+        The number of wells that are requested per page. This number determines in how
+        many pieces the request is splitted. The default is 1000.
+    organisation : str, optional
+        The organisation that manages the wells. If not None, the organisation will be
+        used to filter the wells. The default is None.
+    well_site : str, optional
+        The name of well site the wells belong to. If not None, the well site will be
+        used to filter the wells. The default is None.
+    status : str, optional
+        The status of the wells. If not None, the status will be used to filter the
+        wells. Possible values are "Active", "Inactive" or "Abandoned". The default is
+        None.
+    well_index : str, tuple or list, optional
+        The column(s) in the resulting GeoDataFrame that is/are used as the index of
+        this GeoDataFrame. The default is "Name".
+    **kwargs : dict
+        Kwargs are passed as additional parameters in the request to the database. For
+        available parameters see https://gwo.nhi.nu/api/v1/download/.
+
+    Returns
+    -------
+    gdf : geopandas.GeoDataFrame
+        A GeodDataFrame containing the properties of the wells and their filters.
+
+    """
+    # zie https://gwo.nhi.nu/api/v1/download/
+    url = "https://gwo.nhi.nu/api/v1/well_filters/"
+
+    page = 1
+    properties = []
+    while page is not None:
+        params = {"format": "csv", "n_well_filters": n_well_filters, "page": page}
+        if status is not None:
+            params["well__status"] = status
+        if organisation is not None:
+            params["well__organization"] = organisation
+        if well_site is not None:
+            params["well__site"] = well_site
+        params.update(kwargs)
+
+        r = requests.get(url, auth=(username, password), params=params)
+        content = r.content.decode("utf-8")
+        df = pd.read_csv(io.StringIO(content), skiprows=list(range(8)) + [9], sep=";")
+        properties.append(df)
+
+        if len(df) == n_well_filters:
+            page += 1
+        else:
+            page = None
+    df = pd.concat(properties)
+    geometry = gpd.points_from_xy(df.XCoordinate, df.YCoordinate)
+    gdf = gpd.GeoDataFrame(df, geometry=geometry)
+    if well_index is not None:
+        gdf = gdf.set_index(well_index)
+    return gdf
+
+
+def get_gwo_measurements(
+    username,
+    password,
+    n_measurements=10_000,
+    well_site=None,
+    well_index="Name",
+    measurement_index=("Name", "DateTime"),
+    **kwargs,
+):
+    """
+    Get extraction rates and metadata of wells from the NHI GWO database
+
+    Parameters
+    ----------
+    username : str
+        The username of the NHI GWO database. To retreive a username and password visit
+        https://gwo.nhi.nu/register/.
+    password : TYPE
+        The password of the NHI GWO database. To retreive a username and password visit
+        https://gwo.nhi.nu/register/.
+    n_measurements : int, optional
+        The number of measurements that are requested per page, with a maximum of
+        200000. This number determines in how many pieces the request is splitted. The
+        default is 10000.
+    well_site : str, optional
+        The name of well site the wells belong to. If not None, the well site will be
+        used to filter the wells. The default is None.
+    well_index : str, tuple or list, optional
+        The column(s) in the resulting GeoDataFrame that is/are used as the index of
+        this GeoDataFrame. The default is "Name".
+    measurement_index :  str, tuple or list, optional, optional
+        The column(s) in the resulting measurement-DataFrame that is/are used as the
+        index of this DataFrame. The default is ("Name", "DateTime").
+    **kwargs : dict
+        Kwargs are passed as additional parameters in the request to the database. For
+        available parameters see https://gwo.nhi.nu/api/v1/download/.
+
+    Returns
+    -------
+    measurements : pandas.DataFrame
+        A DataFrame containing the extraction rates of the wells in the database.
+    gdf : geopandas.GeoDataFrame
+        A GeodDataFrame containing the properties of the wells and their filters.
+
+    """
+    url = "http://gwo.nhi.nu/api/v1/measurements/"
+    properties = []
+    measurements = []
+    page = 1
+    while page is not None:
+        params = {
+            "format": "csv",
+            "n_measurements": n_measurements,
+            "page": page,
+        }
+        if well_site is not None:
+            params["filter__well__site"] = well_site
+        params.update(kwargs)
+        r = requests.get(url, auth=(username, password), params=params)
+
+        content = r.content.decode("utf-8")
+        lines = content.split("\n")
+        empty_lines = np.where([set(line) == set(";") for line in lines[:100]])[0]
+        assert len(empty_lines) == 2
+
+        # read properties
+        skiprows = list(range(empty_lines[0] + 1)) + [empty_lines[0] + 2]
+        nrows = empty_lines[1] - empty_lines[0] - 3
+        df = pd.read_csv(io.StringIO(content), sep=";", skiprows=skiprows, nrows=nrows)
+        properties.append(df)
+
+        skiprows = list(range(empty_lines[1] + 1)) + [empty_lines[1] + 2]
+        df = pd.read_csv(
+            io.StringIO(content),
+            skiprows=skiprows,
+            sep=";",
+            parse_dates=["DateTime"],
+            dayfirst=True,
+        )
+        measurements.append(df)
+        if len(df) == n_measurements:
+            page += 1
+        else:
+            page = None
+    measurements = pd.concat(measurements)
+    # drop columns without measurements
+    measurements = measurements.loc[:, ~measurements.isna().all()]
+    if measurement_index is not None:
+        if isinstance(measurement_index, tuple):
+            measurement_index = list(measurement_index)
+        measurements = measurements.set_index(["Name", "DateTime"])
+    df = pd.concat(properties)
+    geometry = gpd.points_from_xy(df.XCoordinate, df.YCoordinate)
+    gdf = gpd.GeoDataFrame(df, geometry=geometry)
+    if well_index is not None:
+        gdf = gdf.set_index(well_index)
+        # drop duplicate properties from multiple pages
+        gdf = gdf[~gdf.index.duplicated()]
+    return measurements, gdf

--- a/nlmod/read/nhi.py
+++ b/nlmod/read/nhi.py
@@ -196,14 +196,14 @@ def get_gwo_wells(
     Parameters
     ----------
     username : str
-        The username of the NHI GWO database. To retreive a username and password visit
+        The username of the NHI GWO database. To retrieve a username and password visit
         https://gwo.nhi.nu/register/.
-    password : TYPE
-        The password of the NHI GWO database. To retreive a username and password visit
+    password : str
+        The password of the NHI GWO database. To retrieve a username and password visit
         https://gwo.nhi.nu/register/.
     n_well_filters : int, optional
         The number of wells that are requested per page. This number determines in how
-        many pieces the request is splitted. The default is 1000.
+        many pieces the request is split. The default is 1000.
     organisation : str, optional
         The organisation that manages the wells. If not None, the organisation will be
         used to filter the wells. The default is None.
@@ -218,7 +218,8 @@ def get_gwo_wells(
         The column(s) in the resulting GeoDataFrame that is/are used as the index of
         this GeoDataFrame. The default is "Name".
     timeout : int, optional
-        The timeout time of requests to the database. The default is 120.
+        The timeout time (in seconds) for requests to the database. The default is
+        120 seconds.
     **kwargs : dict
         Kwargs are passed as additional parameters in the request to the database. For
         available parameters see https://gwo.nhi.nu/api/v1/download/.
@@ -226,7 +227,7 @@ def get_gwo_wells(
     Returns
     -------
     gdf : geopandas.GeoDataFrame
-        A GeodDataFrame containing the properties of the wells and their filters.
+        A GeoDataFrame containing the properties of the wells and their filters.
 
     """
     # zie https://gwo.nhi.nu/api/v1/download/
@@ -277,15 +278,15 @@ def get_gwo_measurements(
     Parameters
     ----------
     username : str
-        The username of the NHI GWO database. To retreive a username and password visit
+        The username of the NHI GWO database. To retrieve a username and password visit
         https://gwo.nhi.nu/register/.
-    password : TYPE
-        The password of the NHI GWO database. To retreive a username and password visit
+    password : str
+        The password of the NHI GWO database. To retrieve a username and password visit
         https://gwo.nhi.nu/register/.
     n_measurements : int, optional
         The number of measurements that are requested per page, with a maximum of
-        200000. This number determines in how many pieces the request is splitted. The
-        default is 10000.
+        200,000. This number determines in how many pieces the request is split. The
+        default is 10,000.
     well_site : str, optional
         The name of well site the wells belong to. If not None, the well site will be
         used to filter the wells. The default is None.
@@ -296,7 +297,8 @@ def get_gwo_measurements(
         The column(s) in the resulting measurement-DataFrame that is/are used as the
         index of this DataFrame. The default is ("Name", "DateTime").
     timeout : int, optional
-        The timeout time of requests to the database. The default is 120.
+        The timeout time (in seconds) of requests to the database. The default is
+        120 seconds.
     **kwargs : dict
         Kwargs are passed as additional parameters in the request to the database. For
         available parameters see https://gwo.nhi.nu/api/v1/download/.
@@ -306,7 +308,7 @@ def get_gwo_measurements(
     measurements : pandas.DataFrame
         A DataFrame containing the extraction rates of the wells in the database.
     gdf : geopandas.GeoDataFrame
-        A GeodDataFrame containing the properties of the wells and their filters.
+        A GeoDataFrame containing the properties of the wells and their filters.
 
     """
     url = "http://gwo.nhi.nu/api/v1/measurements/"

--- a/tests/test_021_nhi.py
+++ b/tests/test_021_nhi.py
@@ -1,8 +1,10 @@
 import os
 import numpy as np
+import geopandas as gpd
 import tempfile
 import nlmod
 import pytest
+import matplotlib.pyplot as plt
 
 tmpdir = tempfile.gettempdir()
 
@@ -20,3 +22,44 @@ def test_buidrainage():
     # assert that all locations with a positive conductance also have a specified depth
     mask = ds["buisdrain_cond"] > 0
     assert np.all(~np.isnan(ds["buisdrain_depth"].data[mask]))
+
+
+def test_gwo():
+    username = os.environ["NHI_GWO_USERNAME"]
+    password = os.environ["NHI_GWO_PASSWORD"]
+
+    # bijvoorbeeld: download ontrekkingen van Brabant Water
+    wells = nlmod.read.nhi.get_gwo_wells(
+        username=username, password=password, organisation="Brabant Water"
+    )
+    assert isinstance(wells, gpd.GeoDataFrame)
+
+    # download extractions from well "13-PP016" of pomping station Veghel
+    measurements, gdf = nlmod.read.nhi.get_gwo_measurements(
+        username, password, well_site="veghel", filter__well__name="13-PP016"
+    )
+    assert measurements.reset_index()["Name"].isin(gdf.index).all()
+
+
+@pytest.mark.skip("too slow")
+def test_gwo_entire_pumping_station():
+    username = os.environ["NHI_GWO_USERNAME"]
+    password = os.environ["NHI_GWO_PASSWORD"]
+    measurements, gdf = nlmod.read.nhi.get_gwo_measurements(
+        username,
+        password,
+        well_site="veghel",
+    )
+    assert measurements.reset_index()["Name"].isin(gdf.index).all()
+
+    ncols = 3
+    nrows = int(np.ceil(len(gdf.index) / ncols))
+    f, axes = plt.subplots(
+        nrows=nrows, ncols=ncols, figsize=(10, 10), sharex=True, sharey=True
+    )
+    axes = axes.ravel()
+    for name, ax in zip(gdf.index, axes):
+        measurements.loc[name, "Volume"].plot(ax=ax)
+        ax.set_xlabel("")
+        ax.set_title(name)
+    f.tight_layout(pad=0.0)

--- a/tests/test_021_nhi.py
+++ b/tests/test_021_nhi.py
@@ -28,7 +28,7 @@ def test_gwo():
     username = os.environ["NHI_GWO_USERNAME"]
     password = os.environ["NHI_GWO_PASSWORD"]
 
-    # bijvoorbeeld: download ontrekkingen van Brabant Water
+    # download all wells from Brabant Water
     wells = nlmod.read.nhi.get_gwo_wells(
         username=username, password=password, organisation="Brabant Water"
     )


### PR DESCRIPTION
This pull request adds support for the NHI GWO databse with extraction data in the Netherlands, mainly form drinking water companies:
https://gwo.nhi.nu/

Users should register at this website to obtain a username and password. For testing purposes, I added my username and password to the Github-secrets, which are used by the tests.