### PR TITLE
Update cache.py

### DIFF
--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -628,7 +628,7 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
         coords.append("x")
         coords.append("y")
         attrs.append("extent")
-        
+
         if "angrot" in ds.attrs:
             attrs.append("angrot")
 

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -644,7 +644,7 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
 
     if "time" in coords and "time" not in ds.coords:
         raise ValueError("time not in dataset. Run nlmod.time.set_ds_time() first.")
-    
+
     # User-unfriendly error messages
     for datavar in datavars:
         if datavar not in ds.datavars:

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -628,6 +628,9 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
         coords.append("x")
         coords.append("y")
         attrs.append("extent")
+        
+        if "gridtype" in ds.attrs:
+            attrs.append("gridtype")
 
         if "angrot" in ds.attrs:
             attrs.append("angrot")

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -139,7 +139,7 @@ def cache_netcdf(coords_2d=False, coords_3d=False, coords_time=False, datavars=N
                         datavars=datavars,
                         coords=coords,
                         attrs=attrs)
-                    
+
             # only use cache if the cache file and the pickled function arguments exist
             if os.path.exists(fname_cache) and os.path.exists(fname_pickle_cache):
                 # check if you can read the pickle, there are several reasons why a

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -641,7 +641,7 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
     # User-friendly error messages
     if "northsea" in datavars and "northsea" not in ds.datavars:
         raise ValueError("Northsea not in dataset. Run nlmod.read.rws.add_northsea() first.")
-    
+
     if "time" in coords and "time" not in ds.coords:
         raise ValueError("time not in dataset. Run nlmod.time.set_ds_time() first.")
     

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -132,12 +132,12 @@ def cache_netcdf(func, coords_2d=False, coords_3d=False, coords_time=False, data
                 dataset = func_args_dic.pop(key)
 
         dataset = ds_contains(
-            dataset, 
-            coords_2d=coords_2d, 
-            coords_3d=coords_3d, 
-            coords_time=coords_time, 
-            datavars=datavars, 
-            coords=coords, 
+            dataset,
+            coords_2d=coords_2d,
+            coords_3d=coords_3d,
+            coords_time=coords_time,
+            datavars=datavars,
+            coords=coords,
             attrs=attrs)
 
         # only use cache if the cache file and the pickled function arguments exist
@@ -619,7 +619,7 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
             coords = []
         if attrs is None:
             attrs = []
-    
+
     # Add coords, datavars and attrs via shorthands
     if coords_2d or coords_3d:
         coords.append("x")
@@ -660,6 +660,6 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
 
     # Return only the required data
     return xr.Dataset(
-        datavars=ds.datavars[datavars], 
-        coords=ds.coords[coords], 
+        datavars=ds.datavars[datavars],
+        coords=ds.coords[coords],
         attrs={k: ds.attrs[k] for k in attrs})

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -481,24 +481,16 @@ def _update_docstring_and_signature(func):
         cur_param = cur_param[:-1]
     else:
         add_kwargs = None
-    
-    new_param = cur_param + tuple()  # to copy the tuple
-    if all(i.name != "cachedir" for i in cur_param):
-        new_param += (
-            inspect.Parameter(
-                "cachedir", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
-            ),
-        )
-    if all(i.name != "cachename" for i in cur_param):
-        new_param += (
-            inspect.Parameter(
-                "cachename", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
-            ),
-        )
-    
+    new_param = cur_param + (
+        inspect.Parameter(
+            "cachedir", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
+        ),
+        inspect.Parameter(
+            "cachename", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
+        ),
+    )
     if add_kwargs is not None:
         new_param = new_param + (add_kwargs,)
-
     sig = sig.replace(parameters=new_param)
     func.__signature__ = sig
 

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -656,11 +656,11 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
     for datavar in datavars:
         if datavar not in ds.datavars:
             raise ValueError(f"{datavar} not in dataset.datavars")
-    
+
     for coord in coords:
         if coord not in ds.coords:
             raise ValueError(f"{coord} not in dataset.coords")
-        
+
     for attr in attrs:
         if attr not in ds.attrs:
             raise ValueError(f"{attr} not in dataset.attrs")

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -53,7 +53,7 @@ def clear_cache(cachedir):
                 logger.info(f"removed {fname_nc}")
 
 
-def cache_netcdf(func, coords_2d=False, coords_3d=False, coords_time=False, datavars=[], coords=[], attrs=[]):
+def cache_netcdf(func, coords_2d=False, coords_3d=False, coords_time=False, datavars=None, coords=None, attrs=None):
     """decorator to read/write the result of a function from/to a file to speed
     up function calls with the same arguments. Should only be applied to
     functions that:
@@ -82,20 +82,24 @@ def cache_netcdf(func, coords_2d=False, coords_3d=False, coords_time=False, data
     docstring with a "Returns" heading. If this is not the case an error is
     raised when trying to decorate the function.
 
+    If all kwargs are left to their defaults, the function caches the full dataset.
+
     Parameters
     ----------
+    ds : xr.Dataset
+        Dataset with dimensions and coordinates.
     coords_2d : bool, optional
-        Whether to check for 2D coordinates in ds. Passed to `ds_contains()`. The default is False.
+        Shorthand for adding 2D coordinates. The default is False.
     coords_3d : bool, optional
-        Whether to check for 3D coordinates. Passed to `ds_contains()`. The default is False.
+        Shorthand for adding 3D coordinates. The default is False.
     coords_time : bool, optional
-        Whether to check for time coordinates. Passed to `ds_contains()`. The default is False.
+        Shorthand for adding time coordinates. The default is False.
     datavars : list, optional
-        List of data variables to check for. Passed to `ds_contains()`. The default is [].
+        List of data variables to check for. The default is an empty list.
     coords : list, optional
-        List of coordinates to check for. Passed to `ds_contains()`. The default is [].
+        List of coordinates to check for. The default is an empty list.
     attrs : list, optional
-        List of attributes to check for. Passed to `ds_contains()`. The default is [].
+        List of attributes to check for. The default is an empty list.
     """
 
     # add cachedir and cachename to docstring
@@ -575,9 +579,9 @@ def _check_for_data_array(ds):
     return ds
 
 
-def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavars=[], coords=[], attrs=[]):
+def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavars=None, coords=None, attrs=None):
     """
-    Checks whether all the required data is present in the dataset and returns only the required data.
+    Returns a Dataset containing only the required data.
 
     If all kwargs are left to their defaults, the function returns the full dataset.
 
@@ -586,17 +590,17 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
     ds : xr.Dataset
         Dataset with dimensions and coordinates.
     coords_2d : bool, optional
-        Whether to check for 2D coordinates. The default is False.
+        Shorthand for adding 2D coordinates. The default is False.
     coords_3d : bool, optional
-        Whether to check for 3D coordinates. The default is False.
+        Shorthand for adding 3D coordinates. The default is False.
     coords_time : bool, optional
-        Whether to check for time coordinates. The default is False.
+        Shorthand for adding time coordinates. The default is False.
     datavars : list, optional
-        List of data variables to check for. The default is [].
+        List of data variables to check for. The default is an empty list.
     coords : list, optional
-        List of coordinates to check for. The default is [].
+        List of coordinates to check for. The default is an empty list.
     attrs : list, optional
-        List of attributes to check for. The default is [].
+        List of attributes to check for. The default is an empty list.
 
     Returns
     -------
@@ -607,7 +611,16 @@ def ds_contains(ds, coords_2d=False, coords_3d=False, coords_time=False, datavar
     # Return the full dataset if not configured
     if not coords_2d and not coords_3d and not datavars and not coords and not attrs:
         return ds
+    else:
+        # Initialize lists
+        if datavars is None:
+            datavars = []
+        if coords is None:
+            coords = []
+        if attrs is None:
+            attrs = []
     
+    # Add coords, datavars and attrs via shorthands
     if coords_2d or coords_3d:
         coords.append("x")
         coords.append("y")

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -53,7 +53,7 @@ def clear_cache(cachedir):
                 logger.info(f"removed {fname_nc}")
 
 
-def cache_netcdf(func):
+def cache_netcdf(func, coords_2d=False, coords_3d=False, coords_time=False, datavars=[], coords=[], attrs=[]):
     """decorator to read/write the result of a function from/to a file to speed
     up function calls with the same arguments. Should only be applied to
     functions that:
@@ -81,6 +81,21 @@ def cache_netcdf(func):
     to the decorated function. This assumes that the decorated function has a
     docstring with a "Returns" heading. If this is not the case an error is
     raised when trying to decorate the function.
+
+    Parameters
+    ----------
+    coords_2d : bool, optional
+        Whether to check for 2D coordinates in ds. Passed to `ds_contains()`. The default is False.
+    coords_3d : bool, optional
+        Whether to check for 3D coordinates. Passed to `ds_contains()`. The default is False.
+    coords_time : bool, optional
+        Whether to check for time coordinates. Passed to `ds_contains()`. The default is False.
+    datavars : list, optional
+        List of data variables to check for. Passed to `ds_contains()`. The default is [].
+    coords : list, optional
+        List of coordinates to check for. Passed to `ds_contains()`. The default is [].
+    attrs : list, optional
+        List of attributes to check for. Passed to `ds_contains()`. The default is [].
     """
 
     # add cachedir and cachename to docstring
@@ -112,7 +127,14 @@ def cache_netcdf(func):
                     )
                 dataset = func_args_dic.pop(key)
 
-        dataset = ds_contains(dataset)
+        dataset = ds_contains(
+            dataset, 
+            coords_2d=coords_2d, 
+            coords_3d=coords_3d, 
+            coords_time=coords_time, 
+            datavars=datavars, 
+            coords=coords, 
+            attrs=attrs)
 
         # only use cache if the cache file and the pickled function arguments exist
         if os.path.exists(fname_cache) and os.path.exists(fname_pickle_cache):

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -1846,7 +1846,7 @@ def get_vertices(ds, vert_per_cid=4, epsilon=0, rotated=False):
     return vertices_da
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def mask_model_edge(ds, idomain=None):
     """get data array which is 1 for every active cell (defined by idomain) at
     the boundaries of the model (xmin, xmax, ymin, ymax). Other cells are 0.

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -1846,7 +1846,7 @@ def get_vertices(ds, vert_per_cid=4, epsilon=0, rotated=False):
     return vertices_da
 
 
-@cache.cache_netcdf()
+@cache.cache_netcdf(coords_2d=True)
 def mask_model_edge(ds, idomain=None):
     """get data array which is 1 for every active cell (defined by idomain) at
     the boundaries of the model (xmin, xmax, ymin, ymax). Other cells are 0.

--- a/nlmod/read/ahn.py
+++ b/nlmod/read/ahn.py
@@ -19,7 +19,7 @@ from .webservices import arcrest, wcs
 logger = logging.getLogger(__name__)
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_ahn(ds=None, identifier="AHN4_DTM_5m", method="average", extent=None):
     """Get a model dataset with ahn variable.
 
@@ -192,7 +192,7 @@ def get_ahn_along_line(line, ahn=None, dx=None, num=None, method="linear", plot=
     return z
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_latest_ahn_from_wcs(
     extent=None,
     identifier="dsm_05m",
@@ -308,7 +308,7 @@ def get_ahn4_tiles(extent=None):
     return gdf
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_ahn1(extent, identifier="ahn1_5m", as_data_array=True):
     """Download AHN1.
 
@@ -335,7 +335,7 @@ def get_ahn1(extent, identifier="ahn1_5m", as_data_array=True):
     return da
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_ahn2(extent, identifier="ahn2_5m", as_data_array=True):
     """Download AHN2.
 
@@ -359,7 +359,7 @@ def get_ahn2(extent, identifier="ahn2_5m", as_data_array=True):
     return _download_and_combine_tiles(tiles, identifier, extent, as_data_array)
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_ahn3(extent, identifier="AHN3_5m_DTM", as_data_array=True):
     """Download AHN3.
 
@@ -382,7 +382,7 @@ def get_ahn3(extent, identifier="AHN3_5m_DTM", as_data_array=True):
     return _download_and_combine_tiles(tiles, identifier, extent, as_data_array)
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_ahn4(extent, identifier="AHN4_DTM_5m", as_data_array=True):
     """Download AHN4.
 

--- a/nlmod/read/ahn.py
+++ b/nlmod/read/ahn.py
@@ -19,7 +19,7 @@ from .webservices import arcrest, wcs
 logger = logging.getLogger(__name__)
 
 
-@cache.cache_netcdf()
+@cache.cache_netcdf(coords_2d=True)
 def get_ahn(ds=None, identifier="AHN4_DTM_5m", method="average", extent=None):
     """Get a model dataset with ahn variable.
 

--- a/nlmod/read/geotop.py
+++ b/nlmod/read/geotop.py
@@ -59,7 +59,7 @@ def get_kh_kv_table(kind="Brabant"):
     return df
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def to_model_layers(
     geotop_ds,
     strat_props=None,
@@ -233,7 +233,7 @@ def to_model_layers(
     return ds
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_geotop(extent, url=GEOTOP_URL, probabilities=False):
     """Get a slice of the geotop netcdf url within the extent, set the x and y
     coordinates to match the cell centers and keep only the strat and lithok

--- a/nlmod/read/jarkus.py
+++ b/nlmod/read/jarkus.py
@@ -23,7 +23,7 @@ from ..util import get_da_from_da_ds, get_ds_empty
 logger = logging.getLogger(__name__)
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_bathymetry(ds, northsea, kind="jarkus", method="average"):
     """get bathymetry of the Northsea from the jarkus dataset.
 
@@ -92,7 +92,7 @@ def get_bathymetry(ds, northsea, kind="jarkus", method="average"):
     return ds_out
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_dataset_jarkus(extent, kind="jarkus", return_tiles=False, time=-1):
     """Get bathymetry from Jarkus within a certain extent. If return_tiles is False, the
     following actions are performed:

--- a/nlmod/read/knmi.py
+++ b/nlmod/read/knmi.py
@@ -13,7 +13,7 @@ from ..dims.resample import get_affine_mod_to_world
 logger = logging.getLogger(__name__)
 
 
-@cache.cache_netcdf()
+@cache.cache_netcdf(coords_2d=True, coords_time=True)
 def get_recharge(ds, method="linear", most_common_station=False):
     """add multiple recharge packages to the groundwater flow model with knmi
     data by following these steps:

--- a/nlmod/read/knmi.py
+++ b/nlmod/read/knmi.py
@@ -13,7 +13,7 @@ from ..dims.resample import get_affine_mod_to_world
 logger = logging.getLogger(__name__)
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_recharge(ds, method="linear", most_common_station=False):
     """add multiple recharge packages to the groundwater flow model with knmi
     data by following these steps:

--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -16,7 +16,7 @@ REGIS_URL = "http://www.dinodata.nl:80/opendap/REGIS/REGIS.nc"
 # REGIS_URL = 'https://www.dinodata.nl/opendap/hyrax/REGIS/REGIS.nc'
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_combined_layer_models(
     extent,
     regis_botm_layer="AKc",
@@ -93,7 +93,7 @@ def get_combined_layer_models(
     return combined_ds
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_regis(
     extent,
     botm_layer="AKc",

--- a/nlmod/read/rws.py
+++ b/nlmod/read/rws.py
@@ -37,7 +37,7 @@ def get_gdf_surface_water(ds):
     return gdf_swater
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf()
 def get_surface_water(ds, da_basename):
     """create 3 data-arrays from the shapefile with surface water:
 
@@ -91,7 +91,7 @@ def get_surface_water(ds, da_basename):
     return ds_out
 
 
-@cache.cache_netcdf
+@cache.cache_netcdf(coords_2d=True)
 def get_northsea(ds, da_name="northsea"):
     """Get Dataset which is 1 at the northsea and 0 everywhere else. Sea is
     defined by rws surface water shapefile.

--- a/nlmod/read/rws.py
+++ b/nlmod/read/rws.py
@@ -37,7 +37,7 @@ def get_gdf_surface_water(ds):
     return gdf_swater
 
 
-@cache.cache_netcdf()
+@cache.cache_netcdf(coords_2d=True)
 def get_surface_water(ds, da_basename):
     """create 3 data-arrays from the shapefile with surface water:
 


### PR DESCRIPTION
The netcdf cache function validates the cache by comparing the ds argument and other function arguments to the pickled arguments. If they match, the cache can be used.

Currently, just the coordinates of the argument ds and the output ds had to match, introducing two errors:
- If the data_vars differ and are used the cache is falsely valid
- The coordintates of the ds argument have to match the coordinates of the output ds. This limits the use of the cache function.

The PR compares the hash of the coords and data_vars of the ds argument to those that were stored in the pickle together with the cached output ds.

Ideally, the cache.cache_netcdf() accepts arguments that specify specifically which data_vars and coords need to be included in the validation check. ~~Beyond the scope of this pr.~~ Part of this PR.