### PR TITLE
Fix regis URL

### DIFF
--- a/nlmod/read/geotop.py
+++ b/nlmod/read/geotop.py
@@ -13,7 +13,7 @@ from ..util import MissingValueError
 
 logger = logging.getLogger(__name__)
 
-GEOTOP_URL = r"http://www.dinodata.nl/opendap/GeoTOP/geotop.nc"
+GEOTOP_URL = "https://dinodata.nl/opendap/GeoTOP/geotop.nc"
 
 
 def get_lithok_props(rgb_colors=True):
@@ -591,7 +591,7 @@ def aggregate_to_ds(
             if "layer" in top.dims:
                 top = top[0].drop_vars("layer")
         else:
-            if "layer" in  ds["top"].dims:
+            if "layer" in ds["top"].dims:
                 top = ds["top"][ilay].drop_vars("layer")
             else:
                 top = ds["botm"][ilay - 1].drop_vars("layer")

--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -12,8 +12,8 @@ from . import geotop
 
 logger = logging.getLogger(__name__)
 
-REGIS_URL = "http://dinodata.nl/opendap/REGIS/REGIS.nc"
-
+#REGIS_URL = "http://www.dinodata.nl:80/opendap/REGIS/REGIS.nc"
+REGIS_URL = "https://www.dinodata.nl/opendap/hyrax/REGIS/REGIS.nc"
 
 @cache.cache_netcdf()
 def get_combined_layer_models(

--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -12,7 +12,7 @@ from . import geotop
 
 logger = logging.getLogger(__name__)
 
-REGIS_URL = "https://dinodata.nl/opendap/REGIS/REGIS.nc"
+REGIS_URL = "http://dinodata.nl/opendap/REGIS/REGIS.nc"
 
 
 @cache.cache_netcdf()

--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -12,8 +12,8 @@ from . import geotop
 
 logger = logging.getLogger(__name__)
 
-#REGIS_URL = "http://www.dinodata.nl:80/opendap/REGIS/REGIS.nc"
-REGIS_URL = "https://www.dinodata.nl/opendap/hyrax/REGIS/REGIS.nc"
+REGIS_URL = "https://dinodata.nl/opendap/REGIS/REGIS.nc"
+
 
 @cache.cache_netcdf()
 def get_combined_layer_models(

--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -12,8 +12,7 @@ from . import geotop
 
 logger = logging.getLogger(__name__)
 
-REGIS_URL = "http://www.dinodata.nl:80/opendap/REGIS/REGIS.nc"
-# REGIS_URL = 'https://www.dinodata.nl/opendap/hyrax/REGIS/REGIS.nc'
+REGIS_URL = "https://dinodata.nl/opendap/REGIS/REGIS.nc"
 
 
 @cache.cache_netcdf()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ grib = ["cfgrib", "ecmwflibs"]
 test = ["pytest>=7", "pytest-cov", "pytest-dependency"]
 nbtest = ["nbformat", "nbconvert>6.4.5"]
 lint = ["flake8", "isort", "black[jupyter]"]
-ci = ["nlmod[full,lint,test,nbtest]", "netCDF4>=1.6.3", "pandas<2.1.0"]
+ci = ["nlmod[full,lint,test,nbtest]", "netCDF4<1.7.0", "pandas<2.1.0"]
 rtd = [
     "nlmod[full]",
     "ipython",
@@ -78,7 +78,7 @@ rtd = [
     "nbsphinx",
     "sphinx_rtd_theme==1.0.0",
     "nbconvert==7.13.0",
-    "netCDF4>=1.6.3",
+    "netCDF4<1.7.0",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
This PR simplifies the REGIS- and GeoTOP-urls, to the openda[-server named on https://www.dinoloket.nl/modelbestanden-aanvragen/netcdf. It also sets the version of the netcdf4 package to below 1.70, because of issue #353.