### PR TITLE
Patch auto-download executables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,6 @@ jobs:
           # exit-zero treats all errors as warnings.
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics
 
-      - name: Download executables needed for tests
-        shell: bash -l {0}
-        run: |
-          python -c "import nlmod; nlmod.util.download_mfbinaries()"
-
       - name: Run tests only
         env:
             NHI_GWO_USERNAME: ${{ secrets.NHI_GWO_USERNAME}}

--- a/README.md
+++ b/README.md
@@ -66,11 +66,4 @@ notoriously hard to install on certain platforms. Please see the
 
 ## Getting started
 
-If you are using `nlmod` for the first time you need to download the MODFLOW
-executables. You can easily download these executables by running this Python code:
-
-    import nlmod
-	nlmod.download_mfbinaries()
-
-After you've downloaded the executables you can run the Jupyter Notebooks in the
-examples folder. These notebooks illustrate how to use the `nlmod` package.
+Start with the Jupyter Notebooks in the examples folder. These notebooks illustrate how to use the `nlmod` package.

--- a/docs/examples/00_model_from_scratch.ipynb
+++ b/docs/examples/00_model_from_scratch.ipynb
@@ -40,25 +40,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Download MODFLOW-binaries\n",
-    "To run MODFLOW, we need to download the MODFLOW-excecutables. We do this with the following code:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if not nlmod.util.check_presence_mfbinaries():\n",
-    "    nlmod.download_mfbinaries()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Model parameters"
    ]
   },

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -72,10 +72,8 @@ MODFLOW 6 model given a model dataset::
 
     # ... add some boundary condition packages (GHB, RIV, DRN, ...)
 
-Running the model requires the modflow binaries provided by the USGS. Those can
-be downloaded with::
-
-    nlmod.download_mfbinaries()
+The MODFLOW 6 executable is automatically downloaded and installed to your system
+when building the first model.
 
 Writing and running the model can then be done using::
 

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -409,6 +409,17 @@ def download_mfbinaries(bindir=None, version_tag="latest", repo="executables"):
 
     get_modflow(bindir=str(bindir), release_id=version_tag, repo=repo)
 
+    # Ensure metadata is saved.
+    # https://github.com/modflowpy/flopy/blob/
+    # 0748dcb9e4641b5ad9616af115dd3be906f98f50/flopy/utils/get_modflow.py#L623
+    flopy_metadata_fp = flopy_appdata_path / "get_modflow.json"
+    if not flopy_metadata_fp.exists():
+        meta = get_release(tag=version_tag, repo=repo, quiet=True)
+        meta["bindir"] = str(bindir)
+
+        with open(flopy_metadata_fp, "w") as f:
+            json.dump([meta], f, indent=4)
+
     # download the provisional version of modpath from Github
     download_modpath_provisional_exe(bindir=bindir, timeout=120)
 

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -4,7 +4,6 @@ import os
 import re
 import sys
 from pathlib import Path
-from tkinter import W
 import warnings
 from typing import Dict, Optional
 

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -415,11 +415,13 @@ def download_mfbinaries(bindir=None, version_tag="latest", repo="executables"):
     flopy_metadata_fp = flopy_appdata_path / "get_modflow.json"
 
     if not flopy_metadata_fp.exists():
-        logger.warning(
-            f"flopy metadata file not found at {flopy_metadata_fp}. "
-            "After downloading and installing the executables. "
-            "Most likely the script is run via pytest. Creating a new metadata file."
-        )
+        if "pytest" not in str(bindir) and "pytest" not in sys.modules:
+            logger.warning(
+                f"flopy metadata file not found at {flopy_metadata_fp}. "
+                "After downloading and installing the executables. "
+                "Creating a new metadata file."
+            )
+
         release_metadata = get_release(tag=version_tag, repo=repo, quiet=True)
         install_metadata = {
             "release_id": release_metadata["tag_name"],

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -201,7 +201,7 @@ def get_bin_directory(
     Parameters
     ----------
     exe_name : str, optional
-        The name of the executable, by default None.
+        The name of the executable, by default mf6.
     bindir : Path, optional
         The directory where the executables are stored, by default "mf6".
     download_if_not_found : bool, optional
@@ -211,12 +211,13 @@ def get_bin_directory(
         "modflow6", or "modflow6-nightly-build". If repo and version_tag are
         provided the most recent installation location of MODFLOW is found in flopy metadata
         that respects `version_tag` and `repo`. If not found, the executables are downloaded
-        using repo and version_tag.
+        using repo and version_tag. repo cannot be None. 
     version_tag : str, default None
         GitHub release ID: for example "18.0" or "latest". If repo and version_tag are
         provided the most recent installation location of MODFLOW is found in flopy metadata
         that respects `version_tag` and `repo`. If not found, the executables are downloaded
-        using repo and version_tag.
+        using repo and version_tag. If version_tag is None, no version check is performed
+        on present executables and if no exe is found, the latest version is downloaded.
 
     Returns
     -------
@@ -233,7 +234,7 @@ def get_bin_directory(
     if sys.platform.startswith("win") and not exe_name.endswith(".exe"):
         exe_name += ".exe"
 
-    enable_version_check = version_tag is not None and repo is not None
+    enable_version_check = version_tag is not None
 
     # If exe_name is a full path
     if Path(exe_name).exists():
@@ -283,7 +284,11 @@ def get_bin_directory(
 
     # Else download the executables
     if download_if_not_found:
-        download_mfbinaries(bindir=bindir, version_tag=version_tag, repo=repo)
+        download_mfbinaries(
+            bindir=bindir, 
+            version_tag=version_tag if version_tag is not None else "latest", 
+            repo=repo
+        )
 
         # Rerun this function
         return get_bin_directory(

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -413,17 +413,22 @@ def download_mfbinaries(bindir=None, version_tag="latest", repo="executables"):
     # https://github.com/modflowpy/flopy/blob/
     # 0748dcb9e4641b5ad9616af115dd3be906f98f50/flopy/utils/get_modflow.py#L623
     flopy_metadata_fp = flopy_appdata_path / "get_modflow.json"
+
     if not flopy_metadata_fp.exists():
         logger.warning(
             f"flopy metadata file not found at {flopy_metadata_fp}. "
             "After downloading and installing the executables. "
             "Most likely the script is run via pytest. Creating a new metadata file."
         )
-        meta = get_release(tag=version_tag, repo=repo, quiet=True)
-        meta["bindir"] = str(bindir)
+        release_metadata = get_release(tag=version_tag, repo=repo, quiet=True)
+        install_metadata = {
+            "release_id": release_metadata["tag_name"],
+            "repo": repo,
+            "bindir": str(bindir),
+        }
 
-        with open(flopy_metadata_fp, "w") as f:
-            json.dump([meta], f, indent=4)
+        with open(flopy_metadata_fp, "w", encoding="UTF-8") as f:
+            json.dump([install_metadata], f, indent=4)
 
     # download the provisional version of modpath from Github
     download_modpath_provisional_exe(bindir=bindir, timeout=120)

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -285,8 +285,8 @@ def get_bin_directory(
     # Else download the executables
     if download_if_not_found:
         download_mfbinaries(
-            bindir=bindir, 
-            version_tag=version_tag if version_tag is not None else "latest", 
+            bindir=bindir,
+            version_tag=version_tag if version_tag is not None else "latest",
             repo=repo
         )
 

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from tkinter import W
 import warnings
 from typing import Dict, Optional
 
@@ -414,6 +415,11 @@ def download_mfbinaries(bindir=None, version_tag="latest", repo="executables"):
     # 0748dcb9e4641b5ad9616af115dd3be906f98f50/flopy/utils/get_modflow.py#L623
     flopy_metadata_fp = flopy_appdata_path / "get_modflow.json"
     if not flopy_metadata_fp.exists():
+        logger.warning(
+            f"flopy metadata file not found at {flopy_metadata_fp}. "
+            "After downloading and installing the executables. "
+            "Most likely the script is run via pytest. Creating a new metadata file."
+        )
         meta = get_release(tag=version_tag, repo=repo, quiet=True)
         meta["bindir"] = str(bindir)
 


### PR DESCRIPTION
- download_mfbinaries() should not retreive any None values for version_tags. Which was the case if: no mf6 was ever downloaded on your system and no version_tag was specified in get_bin_directory() or to_model_ds() .
- Remove explicit download commands and rely on auto download of executables. Closes #348 