### PR TITLE
add modelextent plot

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -29,6 +29,8 @@ pylint:
     - too-many-branches
     - too-many-statements
     - logging-fstring-interpolation
+    - import-outside-toplevel
+    - implicit-str-concat
 
 mccabe:
   disable:

--- a/docs/examples/01_basic_model.ipynb
+++ b/docs/examples/01_basic_model.ipynb
@@ -18,7 +18,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "import nlmod"
    ]
   },

--- a/docs/examples/04_modifying_layermodels.ipynb
+++ b/docs/examples/04_modifying_layermodels.ipynb
@@ -455,7 +455,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set mimimum layer thickness\n",
+    "## Set minimum layer thickness\n",
     "nlmod.layers.set_minimum layer_thickness increases the thickness of a layer if the thickness is less than a specified value.  With a parameter called 'change' you can specify in which direction the layer is changed. The only supported option for now is 'botm', which changes the layer botm. \n",
     "\n",
     "This method only changes the shape of the layer, and does not check if all hydrological properties are defined for cells that had a thickness of 0 before."
@@ -467,7 +467,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# set the mimimum thickness of 'PZWAz2' to 20 m\n",
+    "# set the minimum thickness of 'PZWAz2' to 20 m\n",
     "ds_new = nlmod.layers.set_minimum_layer_thickness(ds.copy(deep=True), \"PZWAz2\", 20.0)\n",
     "compare_layer_models(ds, line, colors, ds2=ds_new, title2=\"Modified\")"
    ]

--- a/docs/examples/11_grid_rotation.ipynb
+++ b/docs/examples/11_grid_rotation.ipynb
@@ -131,7 +131,7 @@
    "outputs": [],
    "source": [
     "# Download AHN\n",
-    "extent = nlmod.resample.get_extent(ds)\n",
+    "extent = nlmod.grid.get_extent(ds)\n",
     "ahn = nlmod.read.ahn.get_ahn3(extent)\n",
     "\n",
     "# Resample to the grid\n",
@@ -320,8 +320,8 @@
     "cbar = nlmod.plot.colorbar_inside(pc)\n",
     "# as the surface water shapes are in model coordinates, we need to transform them\n",
     "# to real-world coordinates before plotting\n",
-    "affine = nlmod.resample.get_affine_mod_to_world(ds)\n",
-    "bgt_rw = nlmod.resample.affine_transform_gdf(bgt, affine)\n",
+    "affine = nlmod.grid.get_affine_mod_to_world(ds)\n",
+    "bgt_rw = nlmod.grid.affine_transform_gdf(bgt, affine)\n",
     "bgt_rw.plot(ax=ax, edgecolor=\"k\", facecolor=\"none\")"
    ]
   },

--- a/nlmod/dims/__init__.py
+++ b/nlmod/dims/__init__.py
@@ -2,7 +2,7 @@
 from . import base, grid, layers, resample, time
 from .attributes_encodings import *
 from .base import *
-from .grid import *
-from .layers import *
 from .resample import *
+from .grid import *  # import from grid after resample, to ignore deprecated methods
+from .layers import *
 from .time import *

--- a/nlmod/dims/base.py
+++ b/nlmod/dims/base.py
@@ -8,7 +8,7 @@ from scipy.spatial import cKDTree
 
 from .. import util
 from ..epsg28992 import EPSG_28992
-from . import resample
+from . import resample, grid
 from .layers import fill_nan_top_botm_kh_kv
 
 logger = logging.getLogger(__name__)
@@ -364,7 +364,7 @@ def _get_structured_grid_ds(
     }
 
     if angrot != 0.0:
-        affine = resample.get_affine_mod_to_world(attrs)
+        affine = grid.get_affine_mod_to_world(attrs)
         xc, yc = affine * np.meshgrid(xcenters, ycenters)
         coords["xc"] = (("y", "x"), xc)
         coords["yc"] = (("y", "x"), yc)
@@ -645,7 +645,7 @@ def get_ds(
     x, y = resample.get_xy_mid_structured(attrs["extent"], delr, delc)
     coords = {"x": x, "y": y, "layer": layer}
     if angrot != 0.0:
-        affine = resample.get_affine_mod_to_world(attrs)
+        affine = grid.get_affine_mod_to_world(attrs)
         xc, yc = affine * np.meshgrid(x, y)
         coords["xc"] = (("y", "x"), xc)
         coords["yc"] = (("y", "x"), yc)

--- a/nlmod/dims/base.py
+++ b/nlmod/dims/base.py
@@ -8,7 +8,7 @@ from scipy.spatial import cKDTree
 
 from .. import util
 from ..epsg28992 import EPSG_28992
-from . import resample, grid
+from . import grid, resample
 from .layers import fill_nan_top_botm_kh_kv
 
 logger = logging.getLogger(__name__)

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -6,6 +6,7 @@
 -   fill, interpolate and resample grid data
 """
 
+# ruff: noqa: E402
 import logging
 import os
 import warnings

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -28,7 +28,6 @@ from shapely.geometry import Point, Polygon
 from tqdm import tqdm
 
 from .. import cache, util
-from .base import _get_structured_grid_ds, _get_vertex_grid_ds, extrapolate_ds
 from .layers import (
     fill_nan_top_botm_kh_kv,
     get_first_active_layer,
@@ -312,6 +311,7 @@ def modelgrid_to_ds(mg):
     """
     if mg.grid_type == "structured":
         x, y = mg.xyedges
+        from .base import _get_structured_grid_ds
 
         ds = _get_structured_grid_ds(
             xedges=x,
@@ -326,6 +326,8 @@ def modelgrid_to_ds(mg):
             crs=None,
         )
     elif mg.grid_type == "vertex":
+        from .base import _get_vertex_grid_ds
+
         ds = _get_vertex_grid_ds(
             x=mg.xcellcenters,
             y=mg.ycellcenters,
@@ -734,6 +736,8 @@ def update_ds_from_layer_ds(ds, layer_ds, method="nearest", **kwargs):
 
         for var in layer_ds.data_vars:
             ds[var] = structured_da_to_ds(layer_ds[var], ds, method=method)
+    from .base import extrapolate_ds
+
     ds = extrapolate_ds(ds)
     ds = fill_nan_top_botm_kh_kv(ds, **kwargs)
     return ds

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -22,6 +22,7 @@ from flopy.utils.gridgen import Gridgen
 from flopy.utils.gridintersect import GridIntersect
 from packaging import version
 from scipy.interpolate import griddata
+from affine import Affine
 from shapely.affinity import affine_transform
 from shapely.geometry import Point, Polygon
 from tqdm import tqdm
@@ -35,14 +36,6 @@ from .layers import (
     remove_inactive_layers,
 )
 from .rdp import rdp
-from .resample import (
-    affine_transform_gdf,
-    get_affine_mod_to_world,
-    get_affine_world_to_mod,
-    structured_da_to_ds,
-    get_delr,
-    get_delc,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -227,6 +220,58 @@ def modelgrid_from_ds(ds, rotated=True, nlay=None, top=None, botm=None, **kwargs
             **kwargs,
         )
     return modelgrid
+
+
+def get_delr(ds):
+    """
+    Get the distance along rows (delr) from the x-coordinate of a structured model
+    dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A model dataset containing an x-coordinate and an attribute 'extent'.
+
+    Returns
+    -------
+    delr : np.ndarray
+        The cell-size along rows (of length ncol).
+
+    """
+    assert ds.gridtype == "structured"
+    x = (ds.x - ds.extent[0]).values
+    delr = _get_delta_along_axis(x)
+    return delr
+
+
+def get_delc(ds):
+    """
+    Get the distance along columns (delc) from the y-coordinate of a structured model
+    dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A model dataset containing an y-coordinate and an attribute 'extent'.
+
+    Returns
+    -------
+    delc : np.ndarray
+        The cell-size along columns (of length nrow).
+
+    """
+    assert ds.gridtype == "structured"
+    y = (ds.extent[3] - ds.y).values
+    delc = _get_delta_along_axis(y)
+    return delc
+
+
+def _get_delta_along_axis(x):
+    """Internal method to determine delr or delc from x or y relative to xmin or ymax"""
+    delr = [x[0] * 2]
+    for xi in x[1:]:
+        delr.append((xi - np.sum(delr)) * 2)
+    return np.array(delr)
 
 
 def modelgrid_to_vertex_ds(mg, ds, nodata=-1):
@@ -575,6 +620,8 @@ def ds_to_gridprops(ds_in, gridprops, method="nearest", icvert_nodata=-1):
         ds_out.coords.update({"layer": ds_in.layer, "x": x, "y": y})
 
         # add other variables
+        from .resample import structured_da_to_ds
+
         for not_interp_var in not_interp_vars:
             ds_out[not_interp_var] = structured_da_to_ds(
                 da=ds_in[not_interp_var], ds=ds_out, method=method, nodata=np.NaN
@@ -683,6 +730,8 @@ def update_ds_from_layer_ds(ds, layer_ds, method="nearest", **kwargs):
         for var in layer_ds.data_vars:
             ds[var] = layer_ds[var]
     else:
+        from .resample import structured_da_to_ds
+
         for var in layer_ds.data_vars:
             ds[var] = structured_da_to_ds(layer_ds[var], ds, method=method)
     ds = extrapolate_ds(ds)
@@ -1978,3 +2027,97 @@ def polygons_from_model_ds(model_ds):
         polygons = [affine_transform(polygon, affine) for polygon in polygons]
 
     return polygons
+
+
+def _get_attrs(ds):
+    if isinstance(ds, dict):
+        return ds
+    else:
+        return ds.attrs
+
+
+def get_extent_polygon(ds, rotated=True):
+    """Get the model extent, as a shapely Polygon."""
+    attrs = _get_attrs(ds)
+    polygon = util.extent_to_polygon(attrs["extent"])
+    if rotated and "angrot" in ds.attrs and attrs["angrot"] != 0.0:
+        affine = get_affine_mod_to_world(ds)
+        polygon = affine_transform(polygon, affine.to_shapely())
+    return polygon
+
+
+def get_extent_gdf(ds, rotated=True, crs="EPSG:28992"):
+    polygon = get_extent_polygon(ds, rotated=rotated)
+    return gpd.GeoDataFrame(geometry=[polygon], crs=crs)
+
+
+def affine_transform_gdf(gdf, affine):
+    """Apply an affine transformation to a geopandas GeoDataFrame."""
+    if isinstance(affine, Affine):
+        affine = affine.to_shapely()
+    gdfm = gdf.copy()
+    gdfm.geometry = gdf.affine_transform(affine)
+    return gdfm
+
+
+def get_extent(ds, rotated=True):
+    """Get the model extent, corrected for angrot if necessary."""
+    attrs = _get_attrs(ds)
+    extent = attrs["extent"]
+    if rotated and "angrot" in attrs and attrs["angrot"] != 0.0:
+        affine = get_affine_mod_to_world(ds)
+        xc = np.array([extent[0], extent[1], extent[1], extent[0]])
+        yc = np.array([extent[2], extent[2], extent[3], extent[3]])
+        xc, yc = affine * (xc, yc)
+        extent = [xc.min(), xc.max(), yc.min(), yc.max()]
+    return extent
+
+
+def get_affine_mod_to_world(ds):
+    """Get the affine-transformation from model to real-world coordinates."""
+    attrs = _get_attrs(ds)
+    xorigin = attrs["xorigin"]
+    yorigin = attrs["yorigin"]
+    angrot = attrs["angrot"]
+    return Affine.translation(xorigin, yorigin) * Affine.rotation(angrot)
+
+
+def get_affine_world_to_mod(ds):
+    """Get the affine-transformation from real-world to model coordinates."""
+    attrs = _get_attrs(ds)
+    xorigin = attrs["xorigin"]
+    yorigin = attrs["yorigin"]
+    angrot = attrs["angrot"]
+    return Affine.rotation(-angrot) * Affine.translation(-xorigin, -yorigin)
+
+
+def get_affine(ds, sx=None, sy=None):
+    """Get the affine-transformation, from pixel to real-world coordinates."""
+    attrs = _get_attrs(ds)
+    if sx is None:
+        sx = get_delr(ds)
+        assert len(np.unique(sx)) == 1, "Affine-transformation needs a constant delr"
+        sx = sx[0]
+    if sy is None:
+        sy = get_delc(ds)
+        assert len(np.unique(sy)) == 1, "Affine-transformation needs a constant delc"
+        sy = sy[0]
+
+    if "angrot" in attrs:
+        xorigin = attrs["xorigin"]
+        yorigin = attrs["yorigin"]
+        angrot = -attrs["angrot"]
+        # xorigin and yorigin represent the lower left corner, while for the transform we
+        # need the upper left
+        dy = attrs["extent"][3] - attrs["extent"][2]
+        xoff = xorigin + dy * np.sin(angrot * np.pi / 180)
+        yoff = yorigin + dy * np.cos(angrot * np.pi / 180)
+        return (
+            Affine.translation(xoff, yoff)
+            * Affine.scale(sx, sy)
+            * Affine.rotation(angrot)
+        )
+    else:
+        xoff = attrs["extent"][0]
+        yoff = attrs["extent"][3]
+        return Affine.translation(xoff, yoff) * Affine.scale(sx, sy)

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -1956,7 +1956,7 @@ def mask_model_edge(ds, idomain=None):
             ds["vertices"] = get_vertices(ds)
         polygons_grid = polygons_from_model_ds(ds)
         gdf_grid = gpd.GeoDataFrame(geometry=polygons_grid)
-        extent_edge = util.polygon_from_extent(ds.extent).exterior
+        extent_edge = get_extent_polygon(ds).exterior
         cids_edge = gdf_grid.loc[gdf_grid.touches(extent_edge)].index
         ds_out["edge_mask"] = util.get_da_from_da_ds(
             ds, dims=("layer", "icell2d"), data=0

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -6,7 +6,6 @@
 -   fill, interpolate and resample grid data
 """
 
-# ruff: noqa: E402
 import logging
 import os
 import warnings

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -16,13 +16,13 @@ import numpy as np
 import pandas as pd
 import shapely
 import xarray as xr
+from affine import Affine
 from flopy.discretization.structuredgrid import StructuredGrid
 from flopy.discretization.vertexgrid import VertexGrid
 from flopy.utils.gridgen import Gridgen
 from flopy.utils.gridintersect import GridIntersect
 from packaging import version
 from scipy.interpolate import griddata
-from affine import Affine
 from shapely.affinity import affine_transform
 from shapely.geometry import Point, Polygon
 from tqdm import tqdm

--- a/nlmod/dims/rdp.py
+++ b/nlmod/dims/rdp.py
@@ -1,8 +1,8 @@
 """
-rdp 
-~~~ 
+rdp
+~~~
 Python implementation of the Ramer-Douglas-Peucker algorithm.
-:copyright: 2014-2016 Fabian Hirschmann <fabian@hirschmann.email> 
+:copyright: 2014-2016 Fabian Hirschmann <fabian@hirschmann.email>
 :license: MIT, see LICENSE.txt for more details.
 """
 

--- a/nlmod/dims/resample.py
+++ b/nlmod/dims/resample.py
@@ -615,7 +615,7 @@ def affine_transform_gdf(gdf, affine):
 def get_extent(ds, rotated=True):
     """Get the model extent, corrected for angrot if necessary."""
     logger.warning(
-        "nlmod.resample.get_extent is deprecated. " "Use nlmod.grid.get_extent instead"
+        "nlmod.resample.get_extent is deprecated. Use nlmod.grid.get_extent instead"
     )
     from .grid import get_extent
 
@@ -647,8 +647,8 @@ def get_affine_world_to_mod(ds):
 def get_affine(ds, sx=None, sy=None):
     """Get the affine-transformation, from pixel to real-world coordinates."""
     logger.warning(
-        "nlmod.resample.get_affine is deprecated. " "Use nlmod.grid.get_affine instead"
+        "nlmod.resample.get_affine is deprecated. Use nlmod.grid.get_affine instead"
     )
     from .grid import get_affine
 
-    return get_affine(ds)
+    return get_affine(ds, sx=sx, sy=sy)

--- a/nlmod/dims/resample.py
+++ b/nlmod/dims/resample.py
@@ -6,10 +6,7 @@ import rasterio
 import xarray as xr
 from scipy.interpolate import griddata
 from scipy.spatial import cKDTree
-
-
 from ..util import get_da_from_da_ds
-
 
 logger = logging.getLogger(__name__)
 

--- a/nlmod/dims/resample.py
+++ b/nlmod/dims/resample.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402
 import logging
 import numbers
 

--- a/nlmod/dims/resample.py
+++ b/nlmod/dims/resample.py
@@ -6,6 +6,7 @@ import rasterio
 import xarray as xr
 from scipy.interpolate import griddata
 from scipy.spatial import cKDTree
+
 from ..util import get_da_from_da_ds
 
 logger = logging.getLogger(__name__)

--- a/nlmod/dims/resample.py
+++ b/nlmod/dims/resample.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import logging
 import numbers
 

--- a/nlmod/gis.py
+++ b/nlmod/gis.py
@@ -4,7 +4,7 @@ import os
 import geopandas as gpd
 import numpy as np
 
-from .dims.grid import polygons_from_model_ds, get_affine_mod_to_world
+from .dims.grid import get_affine_mod_to_world, polygons_from_model_ds
 from .dims.layers import calculate_thickness
 
 logger = logging.getLogger(__name__)

--- a/nlmod/gis.py
+++ b/nlmod/gis.py
@@ -4,8 +4,7 @@ import os
 import geopandas as gpd
 import numpy as np
 
-from .dims.grid import polygons_from_model_ds
-from .dims.resample import get_affine_mod_to_world
+from .dims.grid import polygons_from_model_ds, get_affine_mod_to_world
 from .dims.layers import calculate_thickness
 
 logger = logging.getLogger(__name__)

--- a/nlmod/gwf/gwf.py
+++ b/nlmod/gwf/gwf.py
@@ -6,7 +6,7 @@ import flopy
 import xarray as xr
 
 from ..dims import grid
-from ..dims.grid import get_delr, get_delc
+from ..dims.grid import get_delc, get_delr
 from ..dims.layers import get_idomain
 from ..sim import ims, sim, tdis
 from ..util import _get_value_from_ds_attr, _get_value_from_ds_datavar

--- a/nlmod/gwf/gwf.py
+++ b/nlmod/gwf/gwf.py
@@ -11,7 +11,7 @@ import flopy
 import xarray as xr
 
 from ..dims import grid
-from ..dims.resample import get_delr, get_delc
+from ..dims.grid import get_delr, get_delc
 from ..dims.layers import get_idomain
 from ..sim import ims, sim, tdis
 from ..util import _get_value_from_ds_attr, _get_value_from_ds_datavar

--- a/nlmod/gwf/output.py
+++ b/nlmod/gwf/output.py
@@ -7,8 +7,7 @@ import pandas as pd
 import xarray as xr
 from shapely.geometry import Point
 
-from ..dims.grid import modelgrid_from_ds
-from ..dims.resample import get_affine_world_to_mod
+from ..dims.grid import modelgrid_from_ds, get_affine_world_to_mod
 from ..mfoutput.mfoutput import (
     _get_budget_da,
     _get_heads_da,

--- a/nlmod/gwf/output.py
+++ b/nlmod/gwf/output.py
@@ -7,7 +7,7 @@ import pandas as pd
 import xarray as xr
 from shapely.geometry import Point
 
-from ..dims.grid import modelgrid_from_ds, get_affine_world_to_mod
+from ..dims.grid import get_affine_world_to_mod, modelgrid_from_ds
 from ..mfoutput.mfoutput import (
     _get_budget_da,
     _get_flopy_data_object,

--- a/nlmod/gwf/surface_water.py
+++ b/nlmod/gwf/surface_water.py
@@ -10,9 +10,14 @@ from shapely.geometry import Polygon
 from shapely.strtree import STRtree
 from tqdm import tqdm
 
-from ..dims.grid import gdf_to_grid
+from ..util import extent_to_polygon
+from ..dims.grid import (
+    gdf_to_grid,
+    get_extent_polygon,
+    get_delr,
+    get_delc,
+)
 from ..dims.layers import get_idomain
-from ..dims.resample import get_extent_polygon, extent_to_polygon, get_delr, get_delc
 from ..read import bgt, waterboard
 from ..cache import cache_pickle
 

--- a/nlmod/gwf/surface_water.py
+++ b/nlmod/gwf/surface_water.py
@@ -11,15 +11,15 @@ from shapely.strtree import STRtree
 from tqdm import tqdm
 
 from ..cache import cache_pickle
-from ..util import extent_to_polygon
 from ..dims.grid import (
     gdf_to_grid,
-    get_extent_polygon,
-    get_delr,
     get_delc,
+    get_delr,
+    get_extent_polygon,
 )
 from ..dims.layers import get_idomain
 from ..read import bgt, waterboard
+from ..util import extent_to_polygon
 
 logger = logging.getLogger(__name__)
 

--- a/nlmod/mfoutput/mfoutput.py
+++ b/nlmod/mfoutput/mfoutput.py
@@ -7,9 +7,9 @@ import flopy
 import xarray as xr
 
 from ..dims.grid import (
+    get_affine_mod_to_world,
     get_dims_coords_from_modelgrid,
     modelgrid_from_ds,
-    get_affine_mod_to_world,
 )
 from ..dims.time import ds_time_idx
 from .binaryfile import _get_binary_budget_data, _get_binary_head_data

--- a/nlmod/mfoutput/mfoutput.py
+++ b/nlmod/mfoutput/mfoutput.py
@@ -7,8 +7,11 @@ import xarray as xr
 
 import flopy
 
-from ..dims.grid import get_dims_coords_from_modelgrid, modelgrid_from_ds
-from ..dims.resample import get_affine_mod_to_world
+from ..dims.grid import (
+    get_dims_coords_from_modelgrid,
+    modelgrid_from_ds,
+    get_affine_mod_to_world,
+)
 from ..dims.time import ds_time_idx
 from .binaryfile import _get_binary_budget_data, _get_binary_head_data
 

--- a/nlmod/plot/dcs.py
+++ b/nlmod/plot/dcs.py
@@ -15,8 +15,7 @@ from matplotlib.patches import Rectangle
 from shapely.affinity import affine_transform
 from shapely.geometry import LineString, MultiLineString, Point, Polygon
 
-from ..dims.grid import modelgrid_from_ds
-from ..dims.resample import get_affine_world_to_mod
+from ..dims.grid import modelgrid_from_ds, get_affine_world_to_mod
 from .plotutil import get_map
 
 

--- a/nlmod/plot/dcs.py
+++ b/nlmod/plot/dcs.py
@@ -14,7 +14,7 @@ from matplotlib.patches import Rectangle
 from shapely.affinity import affine_transform
 from shapely.geometry import LineString, MultiLineString, Point, Polygon
 
-from ..dims.grid import modelgrid_from_ds, get_affine_world_to_mod
+from ..dims.grid import get_affine_world_to_mod, modelgrid_from_ds
 from .plotutil import get_map
 
 logger = logging.getLogger(__name__)

--- a/nlmod/plot/plot.py
+++ b/nlmod/plot/plot.py
@@ -13,10 +13,10 @@ from matplotlib.patches import Patch
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from ..dims.grid import (
-    modelgrid_from_ds,
     get_affine_mod_to_world,
     get_extent,
     get_extent_gdf,
+    modelgrid_from_ds,
 )
 from ..read import geotop, rws
 from .dcs import DatasetCrossSection

--- a/nlmod/plot/plot.py
+++ b/nlmod/plot/plot.py
@@ -11,6 +11,8 @@ from matplotlib.collections import PatchCollection
 from matplotlib.colors import ListedColormap, Normalize
 from matplotlib.patches import Patch
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from geopandas import GeoDataFrame
+from shapely.geometry import Polygon
 
 from ..dims.grid import modelgrid_from_ds
 from ..dims.resample import get_affine_mod_to_world, get_extent
@@ -45,6 +47,47 @@ def modelgrid(ds, ax=None, **kwargs):
     if extent is not None:
         ax.axis(extent)
 
+    return ax
+
+
+def modelextent(ds, ax=None, **kwargs):
+    """Plot model extent.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset containing the data.
+    ax : matplotlib.axes.Axes, optional
+        The axes object to plot on. If not provided, a new figure and axes will be
+        created.
+    **kwargs
+        Additional keyword arguments to pass to the boundary plot.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        axes object
+    """
+    extent = xmin, xmax, ymin, ymax = get_extent(ds, rotated=True)
+    dx = 0.05 * (xmax - xmin)
+    dy = 0.05 * (ymax - ymin)
+    if ax is None:
+        _, ax = plt.subplots(figsize=(10, 10))
+        ax.axis("scaled")
+
+        ax.axis([xmin - dx, xmax + dx, ymin - dy, ymax + dy])
+    xy = [
+        (xmin, ymin),
+        (xmax, ymin),
+        (xmax, ymax),
+        (xmin, ymax),
+        (xmin, ymin),
+    ]
+    gdf = GeoDataFrame(geometry=[Polygon(xy)])
+    extent = None if ax.get_autoscale_on() else ax.axis()
+    gdf.boundary.plot(ax=ax, **kwargs)
+    if extent is not None:
+        ax.axis(extent)
     return ax
 
 

--- a/nlmod/plot/plot.py
+++ b/nlmod/plot/plot.py
@@ -59,9 +59,14 @@ def modelextent(ds, dx=None, ax=None, rotated=True, **kwargs):
     ----------
     ds : xarray.Dataset
         The dataset containing the data.
+    dx : float, optional
+        The buffer around the model extent. Default is 5% of the longest model edge.
     ax : matplotlib.axes.Axes, optional
         The axes object to plot on. If not provided, a new figure and axes will be
         created.
+    rotated : bool, optional
+        Plot the model extent in real-world coordinates for rotated grids. Default is
+        True. Set to False to plot model extent in local coordinates.
     **kwargs
         Additional keyword arguments to pass to the boundary plot.
 

--- a/nlmod/plot/plotutil.py
+++ b/nlmod/plot/plotutil.py
@@ -3,7 +3,7 @@ import numpy as np
 from matplotlib.patches import Polygon
 from matplotlib.ticker import FuncFormatter, MultipleLocator
 
-from ..dims.resample import get_affine_mod_to_world
+from ..dims.grid import get_affine_mod_to_world
 from ..epsg28992 import EPSG_28992
 
 

--- a/nlmod/read/ahn.py
+++ b/nlmod/read/ahn.py
@@ -13,7 +13,8 @@ from rasterio.io import MemoryFile
 from tqdm import tqdm
 
 from .. import cache
-from ..dims.resample import get_extent, structured_da_to_ds
+from ..dims.grid import get_extent
+from ..dims.resample import structured_da_to_ds
 from ..util import get_ds_empty
 from .webservices import arcrest, wcs
 

--- a/nlmod/read/bgt.py
+++ b/nlmod/read/bgt.py
@@ -10,7 +10,7 @@ import pandas as pd
 import requests
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 
-from ..dims.resample import extent_to_polygon
+from ..util import extent_to_polygon
 
 
 def get_bgt(

--- a/nlmod/read/jarkus.py
+++ b/nlmod/read/jarkus.py
@@ -7,6 +7,7 @@
 
 Note: if you like jazz please check this out: https://www.northseajazz.com
 """
+
 import datetime as dt
 import logging
 import os
@@ -17,7 +18,8 @@ import requests
 import xarray as xr
 
 from .. import cache
-from ..dims.resample import fillnan_da, get_extent, structured_da_to_ds
+from ..dims.grid import get_extent
+from ..dims.resample import fillnan_da, structured_da_to_ds
 from ..util import get_da_from_da_ds, get_ds_empty
 
 logger = logging.getLogger(__name__)

--- a/nlmod/read/knmi.py
+++ b/nlmod/read/knmi.py
@@ -7,8 +7,8 @@ import pandas as pd
 from hydropandas.io import knmi as hpd_knmi
 
 from .. import cache, util
-from ..dims.layers import get_first_active_layer
 from ..dims.grid import get_affine_mod_to_world
+from ..dims.layers import get_first_active_layer
 
 logger = logging.getLogger(__name__)
 

--- a/nlmod/read/knmi.py
+++ b/nlmod/read/knmi.py
@@ -8,7 +8,7 @@ from hydropandas.io import knmi as hpd_knmi
 
 from .. import cache, util
 from ..dims.layers import get_first_active_layer
-from ..dims.resample import get_affine_mod_to_world
+from ..dims.grid import get_affine_mod_to_world
 
 logger = logging.getLogger(__name__)
 

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -13,7 +13,7 @@ import geopandas as gpd
 import requests
 import xarray as xr
 from colorama import Back, Fore, Style
-from shapely.geometry import box
+from shapely.geometry import box, Polygon
 
 logger = logging.getLogger(__name__)
 
@@ -561,6 +561,51 @@ def compare_model_extents(extent1, extent2):
     raise NotImplementedError("other options are not yet implemented")
 
 
+def extent_to_polygon(extent):
+    """Generate a shapely Polygon from an extent ([xmin, xmax, ymin, ymax])
+
+
+    Parameters
+    ----------
+    extent : tuple, list or array
+        extent (xmin, xmax, ymin, ymax).
+
+    Returns
+    -------
+    shapely.geometry.Polygon
+        polygon of the extent.
+
+    """
+    nw = (extent[0], extent[2])
+    no = (extent[1], extent[2])
+    zo = (extent[1], extent[3])
+    zw = (extent[0], extent[3])
+    return Polygon([nw, no, zo, zw])
+
+
+def extent_to_gdf(extent, crs="EPSG:28992"):
+    """Create a geodataframe with a single polygon with the extent given.
+
+    Parameters
+    ----------
+    extent : tuple, list or array
+        extent.
+    crs : str, optional
+        coördinate reference system of the extent, default is EPSG:28992
+        (RD new)
+
+    Returns
+    -------
+    gdf_extent : geopandas.GeoDataFrame
+        geodataframe with extent.
+    """
+
+    geom_extent = extent_to_polygon(extent)
+    gdf_extent = gpd.GeoDataFrame(geometry=[geom_extent], crs=crs)
+
+    return gdf_extent
+
+
 def polygon_from_extent(extent):
     """Create a shapely polygon from a given extent.
 
@@ -574,7 +619,10 @@ def polygon_from_extent(extent):
     polygon_ext : shapely.geometry.polygon.Polygon
         polygon of the extent.
     """
-
+    logger.warning(
+        "nlmod.util.polygon_from_extent is deprecated. "
+        "Use nlmod.util.extent_to_polygon instead"
+    )
     bbox = (extent[0], extent[2], extent[1], extent[3])
     polygon_ext = box(*tuple(bbox))
 
@@ -597,7 +645,10 @@ def gdf_from_extent(extent, crs="EPSG:28992"):
     gdf_extent : GeoDataFrame
         geodataframe with extent.
     """
-
+    logger.warning(
+        "nlmod.util.gdf_from_extent is deprecated. "
+        "Use nlmod.util.extent_to_gdf instead"
+    )
     geom_extent = polygon_from_extent(extent)
     gdf_extent = gpd.GeoDataFrame(geometry=[geom_extent], crs=crs)
 
@@ -621,7 +672,7 @@ def gdf_within_extent(gdf, extent):
         dataframe with only polygon features within the extent.
     """
     # create geodataframe from the extent
-    gdf_extent = gdf_from_extent(extent, crs=gdf.crs)
+    gdf_extent = extent_to_gdf(extent, crs=gdf.crs)
 
     # check type
     geom_types = gdf.geom_type.unique()

--- a/nlmod/util.py
+++ b/nlmod/util.py
@@ -13,7 +13,7 @@ import xarray as xr
 from colorama import Back, Fore, Style
 from flopy.utils import get_modflow
 from flopy.utils.get_modflow import flopy_appdata_path, get_release
-from shapely.geometry import box, Polygon
+from shapely.geometry import Polygon, box
 
 logger = logging.getLogger(__name__)
 
@@ -595,7 +595,6 @@ def compare_model_extents(extent1, extent2):
 def extent_to_polygon(extent):
     """Generate a shapely Polygon from an extent ([xmin, xmax, ymin, ymax])
 
-
     Parameters
     ----------
     extent : tuple, list or array
@@ -630,7 +629,6 @@ def extent_to_gdf(extent, crs="EPSG:28992"):
     gdf_extent : geopandas.GeoDataFrame
         geodataframe with extent.
     """
-
     geom_extent = extent_to_polygon(extent)
     gdf_extent = gpd.GeoDataFrame(geometry=[geom_extent], crs=crs)
 


### PR DESCRIPTION
This PR is originally made by @dbrakenhoff to add a modelextent-plot.

It has been misused by me (@rubencalje) to replace some of the methods from the resample-module to the grid-module. For example the `nlmod.resample.get_extent(ds)` now is `nlmod.grid.get_extent(ds)`, which I think is more logical. The original methods still function, and the user will see a warning that the old methods are deprecated.