### PR TITLE
Update tile retreival ahn.py

### DIFF
--- a/nlmod/read/ahn.py
+++ b/nlmod/read/ahn.py
@@ -582,7 +582,7 @@ def _get_ahn_ellipsis(extent, identifier="AHN5_5M_M", **kwargs):
         url = tiles.at[tile, identifier]
         if url == "nan":
             continue
-        elif url.endswith(".zip"):
+        if url.endswith(".zip"):
             path = url.split("/")[-1].replace(".zip", ".TIF")
             if path.lower().endswith(".tif.tif"):
                 path = path[:-4]


### PR DESCRIPTION
- On the eclipse server: Skip tile retreival if the link does not exist.
- Legacy server: Rasterio merge returned only zero's since 17 sept. All the merging is now done within xarray.