### PR TITLE
Add between_layers to calculate_resistance, and set to False

### DIFF
--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -122,7 +122,7 @@ def calculate_transmissivity(
 
 
 def calculate_resistance(
-    ds, kv="kv", thickness="thickness", top="top", botm="botm", between_layers=False
+    ds, kv="kv", thickness="thickness", top="top", botm="botm", between_layers=None
 ):
     """Calculate vertical resistance (c) of model layers from the vertical conductivity
     (kv) and the thickness.
@@ -147,7 +147,8 @@ def calculate_resistance(
         If True, calculate the resistance between the layers, which MODFLOW uses to
         calculate the flow. The resistance between two layers is then assigned to the
         top layer, and the bottom model layer gets a resistance of infinity.
-        If False, calculate the resistance of the layers themselves. The defauls is
+        If False, calculate the resistance of the layers themselves. The default is
+        True. However, in a future version of nlmod the default will be changed to
         False.
 
     Returns
@@ -155,6 +156,17 @@ def calculate_resistance(
     c : xarray.DataArray
         DataArray containing vertical resistance (c). NaN where layer thickness is zero
     """
+    if between_layers is None:
+        logger.warning(
+            (
+                "The default of between_layers=True in calculate_resistance is "
+                "deprecated and will be changed to False in a future version of nlmod. "
+                "Pass between_layers=True to retain current behavior or "
+                "between_layers=False to adopt the future default and silence "
+                "this warning."
+            )
+        )
+        between_layers = True  # will be changed to False in future version of nlmod
     if thickness in ds:
         thickness = ds[thickness]
     else:
@@ -1198,7 +1210,7 @@ def remove_layer_dim_from_top(
         model DataSet
     check : bool, optional
         If True, checks for inconsistencies in the layer model and report to logger as
-        warning. The defaults is True.
+        warning. The default is True.
     set_non_existing_layers_to_nan bool, optional
         If True, sets the value of the botm-variable to NaN for non-existent layers.
         This is not recommended, as this might break some procedures in nlmod. The


### PR DESCRIPTION
Solves issue #310. This PR changes the outcome of `calculate_resistance`, when `between_layers` is set to False. This will be the new default in the future as well. When `between_layers` is not specified (which is the default), the user will see the following warning:

`The default of between_layers=True in calculate_resistance is deprecated and will be changed to False in a future version of nlmod. Pass between_layers=True to retain current behavior or between_layers=False to adopt the future default and silence this warning.`