### PR TITLE
Parsing of 'c' value as float instead of timedelta[ns]

### DIFF
--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -174,7 +174,7 @@ def get_regis(
 
     # the 'c' value is specified as a timedelta[ns] and should be converted to a float in days.
     # this needs to be done before the NaN replacement of -9999 values.
-    if "c" in variables:
+    if "c" in variables and ds["c"].dtype.type is np.timedelta64:
         ds["c"] = ds["c"] / np.timedelta64(1, "D")
     
     # since version REGIS v02r2s2 (22.07.2024) NaN values are replaced by -9999

--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -172,6 +172,11 @@ def get_regis(
             variables = variables + ("sdh", "sdv")
         ds = ds[list(variables)]
 
+    # the 'c' value is specified as a timedelta[ns] and should be converted to a float in days.
+    # this needs to be done before the NaN replacement of -9999 values.
+    if "c" in variables:
+        ds["c"] = ds["c"] / np.timedelta64(1, "D")
+    
     # since version REGIS v02r2s2 (22.07.2024) NaN values are replaced by -9999
     # we set these values to NaN again
     if nodata is not None:
@@ -198,6 +203,8 @@ def get_regis(
             ds[datavar].attrs["units"] = "mNAP"
         elif datavar in ["kh", "kv"]:
             ds[datavar].attrs["units"] = "m/day"
+        elif datavar in ["c"]:
+            ds[datavar].attrs["units"] = "days"
 
     # set the crs to dutch rd-coordinates
     ds.rio.write_crs(28992, inplace=True)

--- a/tests/test_002_regis_geotop.py
+++ b/tests/test_002_regis_geotop.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-
+import numpy as np
 import nlmod
 
 
@@ -18,6 +18,18 @@ def test_get_regis_botm_layer_BEk1(
     regis_ds = nlmod.read.regis.get_regis(extent, botm_layer)
     assert regis_ds.sizes["layer"] == 15
     assert regis_ds.layer.values[-1] == botm_layer
+
+
+def test_get_regis_only_c(extent=[98700.0, 99000.0, 489500.0, 489700.0]):
+    regis_ds = nlmod.read.regis.get_regis(extent, variables="c")
+    assert np.all([x == "c" for x in regis_ds.data_vars])
+    assert regis_ds.sizes["layer"] == 8
+
+
+def test_get_regis_only_c_and_kd(extent=[98700.0, 99000.0, 489500.0, 489700.0]):
+    regis_ds = nlmod.read.regis.get_regis(extent, variables=["c", "kD"])
+    assert np.all([x in ["c", "kD"] for x in regis_ds.data_vars])
+    assert regis_ds.sizes["layer"] == 18
 
 
 def test_get_geotop(extent=[98600.0, 99000.0, 489400.0, 489700.0]):


### PR DESCRIPTION
By default the 'c' value was read as a timedelta[ns]. So a value of -9999 days was shown as -863913600000000000 nanoseconds and therefore not caught by the NaN replacement in the following lines.