### PR TITLE
Bofek improvements

### DIFF
--- a/nlmod/read/bofek.py
+++ b/nlmod/read/bofek.py
@@ -1,14 +1,13 @@
 import logging
 import shutil
 import zipfile
-from io import BytesIO
 from pathlib import Path
-from tqdm import tqdm
 
 import geopandas as gpd
 import requests
+from tqdm import tqdm
 
-from nlmod import NLMOD_DATADIR, cache, util
+from nlmod import cache, util
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +50,7 @@ def get_gdf_bofek(extent, dirname, timeout=3600):
     fname_7z = dirname / "BOFEK2020_GIS.7z"
     fname_bofek_gdb = dirname / "GIS" / "BOFEK2020_bestanden" / "BOFEK2020.gdb"
 
-    # create directories if they do not exist 
+    # create directories if they do not exist
     dirname.mkdir(exist_ok=True, parents=True)
 
     # url


### PR DESCRIPTION
I got an error using the previous `get_gdf_bofek` function because it automatically writes to the NLMOD_DATADIR. My script did not have write permissions to this directory. Therefore, I added the option to specify a directory yourself.

I also tried very hard to do everything in memory so you don't have to write data to the disk. This involved many steps:
1. read data from URL
2. extract zipped data, this return another 7zip folder
3. extract only the geodatabase files from this folder
4. create a geodataframe from the geodatabase files

I did succeed to do steps 1 and 2 in-memory but I did not succeed to do steps 3 and 4 in-memory. Adding steps 1 and 2 unfortunately removed the progress bar and I am not sure how to get it back. @dbrakenhoff: do you know how to do this?

For future reference: I almost managed to complete steps 3 and 4 using a private method from py7zr. I leave the code here just in case anybody feels like trying this:

```
with py7zr.SevenZipFile(BytesIO(unzipped), mode="r") as a:
    out= a._extract(path=None, return_dict=True, targets=["GIS/BOFEK2020_bestanden/BOFEK2020.gdb"], recursive=True)
    # out= a.extract(path=None, targets=["GIS/BOFEK2020_bestanden/BOFEK2020.gdb"], recursive=True)

zip_buffer = BytesIO()

with ZipFile(zip_buffer, "a", ZIP_DEFLATED, False) as zip_file:
    for file_name, data in out.items():
        zip_file.writestr(file_name, data.getvalue())


with ZipMemoryFile(zip_buffer.getvalue()) as memfile:
    with memfile.open() as src:
        resultaat = gpd.GeoDataframe(src)
```