### PR TITLE
Improve combine layers + some tiny fixes

### DIFF
--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -2266,10 +2266,33 @@ def affine_transform_gdf(gdf, affine):
     return gdfm
 
 
-def get_extent(ds, rotated=True):
-    """Get the model extent, corrected for angrot if necessary."""
+def get_extent(ds, rotated=True, xmargin=0.0, ymargin=0.0):
+    """Get the model extent, corrected for angrot if necessary.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        model dataset.
+    rotated : bool, optional
+        if True, the extent is corrected for angrot. The default is True.
+    xmargin : float, optional
+        margin to add to the x-extent. The default is 0.0.
+    ymargin : float, optional
+        margin to add to the y-extent. The default is 0.0.
+
+    Returns
+    -------
+    extent : list
+        [xmin, xmax, ymin, ymax]
+    """
     attrs = _get_attrs(ds)
     extent = attrs["extent"]
+    extent = [
+        extent[0] - xmargin,
+        extent[1] + xmargin,
+        extent[2] - ymargin,
+        extent[3] + ymargin,
+    ]
     if rotated and "angrot" in attrs and attrs["angrot"] != 0.0:
         affine = get_affine_mod_to_world(ds)
         xc = np.array([extent[0], extent[1], extent[1], extent[0]])

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -642,7 +642,7 @@ def combine_layers_ds(
     logger.info("Calculating new layer tops and bottoms...")
 
     if "layer" in ds[top].dims:
-        msg = "Top in ds has a layer dimension. combine_layers_ds will remove the layer dimension from top in ds."
+        msg = f"datavar {top} has a layer dimension. combine_layers_ds will remove the layer dimension from {top} in ds."
         logger.warning(msg)
     else:
         ds = ds.copy()

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -405,7 +405,7 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
             reindexer[j] = c
             # only need to calculate new top/bot once for each merged layer
             if i == np.min(c):
-                with np.printoptions(legacy="1.25"):
+                with np.printoptions(legacy="1.21"):
                     logger.debug(
                         f"{j:2d}: Merge layers {c} ({old_names}) as layer {j}, "
                         "calculate new top/bot."
@@ -669,7 +669,7 @@ def combine_layers_ds(
     check = [(np.diff(x) == 1).all() for x in combine_layers_integer]
     if not np.all(check):
         msg = ""
-        with np.printoptions(legacy="1.25"):
+        with np.printoptions(legacy="1.21"):
             for m in np.nonzero(~np.array(check))[0]:
                 if isinstance(combine_layers, dict):
                     layer_names = combine_layers[list(combine_layers.keys())[m]]

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -636,14 +636,18 @@ def combine_layers_ds(
 
     dropped_dv = set(ds.data_vars.keys()) - parsed_dv
     if len(dropped_dv) > 0:
-        logger.warning(f"Following data variables will be dropped: {dropped_dv}")
+        msg = f"Following data variables will be dropped: {dropped_dv}"
+        logger.warning(msg)
 
     # calculate new tops/bots
     logger.info("Calculating new layer tops and bottoms...")
 
     if "layer" in ds[top].dims:
-        msg = f"datavar {top} has a layer dimension. combine_layers_ds will remove the layer dimension from {top} in ds."
-        logger.warning(msg)
+        msg = (
+            f"Datavar {top} has a layer dimension. combine_layers_ds will"
+            " remove the layer dimension from {top}."
+        )
+        logger.info(msg)
     else:
         ds = ds.copy()
         ds[top] = ds[bot] + calculate_thickness(ds)
@@ -730,7 +734,7 @@ def combine_layers_ds(
     ds_combine = xr.Dataset(da_dict, attrs=attrs)
 
     # remove layer dimension from top again
-    ds = remove_layer_dim_from_top(ds, inconsistency_threshold=1e-3)
+    ds_combine = remove_layer_dim_from_top(ds_combine, inconsistency_threshold=1e-5)
 
     return ds_combine
 

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -401,14 +401,17 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
         if i in np.concatenate(combine_layers):
             # get indices of layers
             c = combine_layers[icomb]
+            old_names = ds.layer.isel(layer=list(c)).layer.to_numpy().tolist()
             # store new and original layer indices
             reindexer[j] = c
             # only need to calculate new top/bot once for each merged layer
             if i == np.min(c):
-                logger.debug(
-                    f"{j:2d}: Merge layers {c} as layer {j}, calculate new top/bot."
-                )
-                tops = ds[top].data[c, :, :]
+                with np.printoptions(legacy="1.25"):
+                    logger.debug(
+                        f"{j:2d}: Merge layers {c} ({old_names}) as layer {j}, "
+                        "calculate new top/bot."
+                    )
+                tops = ds[top].data[c, ...]
                 bots = ds[bot].data[c, :, :]
                 new_top.data[j] = np.nanmax(tops, axis=0)
                 new_bot.data[j] = np.nanmin(bots, axis=0)
@@ -425,7 +428,7 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
         else:
             # do not merge, only map old layer index to new layer index
             logger.debug(
-                f"{j:2d}: Do not merge, map old layer index to new layer index."
+                f"{j:2d}: Do not merge, map old layer index {i} to new layer index {j}."
             )
             new_top.data[j] = ds[top].data[i]
             new_bot.data[j] = ds[bot].data[i]

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -400,7 +400,7 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
         if i in np.concatenate(combine_layers):
             # get indices of layers
             c = combine_layers[icomb]
-            old_names = ds.layer.isel(layer=list(c)).layer.to_numpy().tolist()
+            old_names = ds.layer.isel(layer=list(c)).to_numpy().tolist()
             # store new and original layer indices
             reindexer[j] = c
             # only need to calculate new top/bot once for each merged layer

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -389,7 +389,7 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
     )
 
     # dict to keep track of old and new layer indices
-    reindexer = dict()
+    reindexer = {}
 
     j = 0  # new layer index
     icomb = 0  # combine layer index
@@ -733,7 +733,7 @@ def combine_layers_ds(
     logger.info("Done! Created new dataset with combined layers!")
     ds_combine = xr.Dataset(da_dict, attrs=attrs)
 
-    # remove layer dimension from top again
+    # remove layer dimension from top
     ds_combine = remove_layer_dim_from_top(ds_combine, inconsistency_threshold=1e-5)
 
     return ds_combine

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -1,6 +1,5 @@
 import logging
 import warnings
-from collections import OrderedDict
 
 import numpy as np
 import xarray as xr
@@ -240,7 +239,7 @@ def split_layers_ds(
     bot : str, optional
         name of data variable containing bottom of layers, by default 'botm'
     return_reindexer : bool, optional
-        Return a OrderedDict that can be used to reindex variables from the original
+        Return a dictionary that can be used to reindex variables from the original
         layer-dimension to the new layer-dimension when True. The default is False.
     start_suffix_at : int, optional
         The suffix that the first splitted layer will receive, for layers that were
@@ -322,7 +321,7 @@ def split_layers_ds(
 
     if return_reindexer:
         # determine reindexer
-        reindexer = OrderedDict(zip(layers, layers_org))
+        reindexer = dict(zip(layers, layers_org))
         for lay0 in split_dict:
             reindexer.pop(lay0)
         return ds, reindexer
@@ -369,7 +368,7 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
     -------
     new_top, new_bot : xarray.DataArrays
         DataArrays containing new tops and bottoms after splitting layers.
-    reindexer : OrderedDict
+    reindexer : dict
         dictionary mapping new to old layer indices.
     """
     # calculate new number of layers
@@ -390,7 +389,7 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
     )
 
     # dict to keep track of old and new layer indices
-    reindexer = OrderedDict()
+    reindexer = dict()
 
     j = 0  # new layer index
     icomb = 0  # combine layer index
@@ -445,7 +444,7 @@ def sum_param_combined_layers(da, reindexer):
     ----------
     da : xarray.DataArray
         data array to calculate combined parameters for
-    reindexer : OrderedDict
+    reindexer : dict
         dictionary mapping new layer indices to old layer indices
 
     Returns

--- a/nlmod/plot/plotutil.py
+++ b/nlmod/plot/plotutil.py
@@ -438,8 +438,8 @@ def add_xsec_line_and_labels(
     mapax.plot(x, y, **kwargs)
     stroke = [patheffects.withStroke(linewidth=2, foreground="w")]
     mapax.text(
-        x[0] + x_offset,
-        y[0] + y_offset,
+        x[0] - x_offset,
+        y[0] - y_offset,
         f"{label}",
         fontweight="bold",
         path_effects=stroke,


### PR DESCRIPTION
Improve combine_layers:
- accept layer names and layer indices  for combine_layers (as both dict and list)
- raise a useful error message when layers are non-consecutive
- better docstrings
- remove unnecessary ordereddict
- deal with single entries in input (#406)

Other fixes:
- tiny change in xsec label placement in add_xsec_line_and_labels
- add xmargin/ymargin to get_extent to expand/shrink extent by some amount in x and y