### PR TITLE
Use hashlib instead of dask.base.tokenize

### DIFF
--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -1025,7 +1025,7 @@ def hash_xarray_data_vars(
         if include_metadata:
             # hash each coordinate separately
             coord_hashes = {}
-            for coord_name, coord in da.coords.items():
+            for coord_name, coord in sorted(da.coords.items()):
                 coord_hashes[coord_name] = hash_xarray_coords(
                     coord, include_metadata=False
                 )

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -940,12 +940,12 @@ def _explicit_dataset_coordinate_comparison(ds_in, ds_cache):
 class NumpyEncoder(json.JSONEncoder):
     """Special json encoder for numpy types."""
 
-    def default(self, obj):
-        if isinstance(obj, np.integer):
-            return int(obj)
-        elif isinstance(obj, np.floating):
-            return float(obj)
-        return json.JSONEncoder.default(self, obj)
+    def default(self, o):
+        if isinstance(o, np.integer):
+            return int(o)
+        elif isinstance(o, np.floating):
+            return float(o)
+        return json.JSONEncoder.default(self, o)
 
 
 def hash_xarray_coords(ds, include_metadata: bool = False):

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -1013,7 +1013,8 @@ def hash_xarray_data_vars(
     # get the raw bytes from the numpy array values
     combined_bytes = b""
     if isinstance(ds, xr.Dataset):
-        data_arrays = [ds[da] for da in ds.data_vars]
+        # sort data vars en ensure hashes remain the same
+        data_arrays = [ds[da] for da in sorted(ds.data_vars)]
     elif isinstance(ds, xr.DataArray):
         data_arrays = [ds]
     else:

--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -2,12 +2,12 @@ import functools
 import hashlib
 import importlib
 import inspect
+import json
 import logging
 import numbers
 import os
 import pickle
 
-import dask
 import flopy
 import joblib
 import numpy as np
@@ -228,10 +228,24 @@ def cache_netcdf(
                         ).hexdigest()
 
                     if dataset is not None:
+                        # fix layer dtype if necessary
+                        if "layer" in dataset.coords:
+                            if dataset["layer"].dtype != cached_ds["layer"].dtype:
+                                # cached layer dtype might be read as fixed width dtype
+                                # modify dataset dtype to make hashes match
+                                dataset = dataset.assign_coords(
+                                    {
+                                        "layer": dataset["layer"].values.astype(
+                                            cached_ds["layer"].dtype
+                                        )
+                                    }
+                                )
                         if NLMOD_CACHE_OPTIONS["dataset_coords_hash"]:
-                            # Check the coords of the dataset argument
-                            func_args_dic["_dataset_coords_hash"] = dask.base.tokenize(
-                                dict(dataset.coords)
+                            # Check the coords of the dataset argument,
+                            # 20250228: metadata is currently excluded as this was
+                            # causing differences that are not relevant to the cache...
+                            func_args_dic["_dataset_coords_hash"] = hash_xarray_coords(
+                                dataset, include_metadata=False
                             )
                         else:
                             func_args_dic_cache.pop("_dataset_coords_hash", None)
@@ -251,8 +265,10 @@ def cache_netcdf(
 
                         if NLMOD_CACHE_OPTIONS["dataset_data_vars_hash"]:
                             # Check the data_vars of the dataset argument
+                            # 20250228: metadata is currently excluded as this was
+                            # causing differences that are not relevant to the cache...
                             func_args_dic["_dataset_data_vars_hash"] = (
-                                dask.base.tokenize(dict(dataset.data_vars))
+                                hash_xarray_data_vars(dataset, include_metadata=False)
                             )
                         else:
                             func_args_dic_cache.pop("_dataset_data_vars_hash", None)
@@ -320,8 +336,10 @@ def cache_netcdf(
                 # Add dataset argument hash to function arguments dic
                 if dataset is not None:
                     if NLMOD_CACHE_OPTIONS["dataset_coords_hash"]:
-                        func_args_dic["_dataset_coords_hash"] = dask.base.tokenize(
-                            dict(dataset.coords)
+                        # 20250228: metadata is currently excluded as this was
+                        # causing differences that are not relevant to the cache...
+                        func_args_dic["_dataset_coords_hash"] = hash_xarray_coords(
+                            dataset, include_metadata=False
                         )
                     else:
                         logger.warning(
@@ -330,8 +348,10 @@ def cache_netcdf(
                             "`nlmod.config.NLMOD_CACHE_OPTIONS`."
                         )
                     if NLMOD_CACHE_OPTIONS["dataset_data_vars_hash"]:
-                        func_args_dic["_dataset_data_vars_hash"] = dask.base.tokenize(
-                            dict(dataset.data_vars)
+                        # 20250228: metadata is currently excluded as this was
+                        # causing differences that are not relevant to the cache...
+                        func_args_dic["_dataset_data_vars_hash"] = (
+                            hash_xarray_data_vars(dataset, include_metadata=False)
                         )
                     else:
                         logger.warning(
@@ -915,3 +935,115 @@ def _explicit_dataset_coordinate_comparison(ds_in, ds_cache):
             return False
     logger.debug("cache -> all coordinates equal")
     return True
+
+
+class NumpyEncoder(json.JSONEncoder):
+    """Special json encoder for numpy types."""
+
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
+def hash_xarray_coords(ds, include_metadata: bool = False):
+    """
+    Create a hash of xarray coordinate(s) using array bytes and optionally metadata.
+
+    Parameters
+    ----------
+    coord : xarray.core.coordinates.Coordinate
+        The xarray coordinate object to hash
+    include_metadata : bool, optional
+        Whether to include metadata in the hash. Default is False.
+
+    Returns
+    -------
+    str
+        The hexadecimal hash string
+    """
+    combined_bytes = b""
+    for coord in ds.coords:
+        # get the raw bytes from the numpy array values
+        values_bytes = ds[coord].values.tobytes()
+        combined_bytes += values_bytes
+
+        if include_metadata:
+            # get metadata as JSON
+            metadata = {
+                "name": coord,
+                "dims": ds[coord].dims,
+                "attrs": ds[coord].attrs,
+                "dtype": str(ds[coord].dtype),
+                "shape": ds[coord].shape,
+            }
+            metadata_bytes = json.dumps(
+                metadata, sort_keys=True, cls=NumpyEncoder
+            ).encode("utf-8")
+
+            # combine both sets of bytes for hashing
+            if include_metadata:
+                combined_bytes += metadata_bytes
+
+    # create a hash of the combined bytes
+    return hashlib.sha256(combined_bytes).hexdigest()
+
+
+def hash_xarray_data_vars(
+    ds,
+    include_metadata: bool = False,
+):
+    """
+    Create a hash of xarray data variables using array bytes and optionally metadata.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset or xarray.DataArray
+        The xarray coordinate object to hash
+    include_metadata : bool, optional
+        Whether to include metadata in the hash. Default is False.
+
+    Returns
+    -------
+    str
+        The hexadecimal hash string
+    """
+    # get the raw bytes from the numpy array values
+    combined_bytes = b""
+    if isinstance(ds, xr.Dataset):
+        data_arrays = [ds[da] for da in ds.data_vars]
+    elif isinstance(ds, xr.DataArray):
+        data_arrays = [ds]
+    else:
+        raise TypeError("Input must be an xarray Dataset or DataArray")
+    for da in data_arrays:
+        combined_bytes += da.values.tobytes()
+
+        if include_metadata:
+            # hash each coordinate separately
+            coord_hashes = {}
+            for coord_name, coord in da.coords.items():
+                coord_hashes[coord_name] = hash_xarray_coords(
+                    coord, include_metadata=False
+                )
+
+            # get metadata as JSON
+            metadata = {
+                "name": da.name,
+                "dims": da.dims,
+                "attrs": da.attrs,
+                "dtype": str(da.dtype),
+                "shape": da.shape,
+                "coord_hashes": coord_hashes,
+            }
+            metadata_bytes = json.dumps(
+                metadata, sort_keys=True, cls=NumpyEncoder
+            ).encode("utf-8")
+
+            # combine both sets of bytes for hashing
+            combined_bytes += metadata_bytes
+
+    # create a hash of the combined bytes
+    return hashlib.sha256(combined_bytes).hexdigest()


### PR DESCRIPTION
Not sure if this PR should be merged, but I wanted to publish this code somewhere. 

This moves all hashing checks away from `dask.base.tokenize` and uses hashlib instead. Two methods are introduced, `hash_xarray_coords()` for checking the coordinates and `hash_xarray_data_vars()` for the data variables. This also gives more fine-grained control over which data to compute the hash for through the `include_metadata` kwarg. The default is False, because I wasn't getting corresponding hashes for my REGIS test dataset when including the metadata.  

With these changes my cached copy of  AHN survives a kernel restart without having to override caching settings introduced in #412. Was it worth it? I'm not sure :P. 

In my opinion this adds even more complexity to the whole caching thing (which was already complicated) so I would actually prefer just to do an explicit coordinate check and ignore all the hash comparisons (great idea on paper, but hard to configure in practice). 

So, curious to hear your thoughts on this. 