### PR TITLE
Combine layers unstructured

### DIFF
--- a/nlmod/dims/attributes_encodings.py
+++ b/nlmod/dims/attributes_encodings.py
@@ -167,9 +167,9 @@ def get_encodings(
         if np.issubdtype(da.dtype, np.character):
             continue
 
-        assert "_FillValue" not in da.attrs, (
-            f"Custom fillvalues are not supported. {varname} has a fillvalue set."
-        )
+        assert (
+            "_FillValue" not in da.attrs
+        ), f"Custom fillvalues are not supported. {varname} has a fillvalue set."
 
         encoding = {
             "zlib": True,

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -54,7 +54,10 @@ def is_structured(ds):
     bool
         True if the dataset is structured.
     """
-    return set(GridTypeDims.STRUCTURED.value).issubset(ds.dims)
+    return GridTypeDims.parse_dims(ds) in (
+        GridTypeDims.STRUCTURED,
+        GridTypeDims.STRUCTURED_LAYERED,
+    )
 
 
 def is_vertex(ds):
@@ -70,7 +73,10 @@ def is_vertex(ds):
     bool
         True if the dataset is structured.
     """
-    return set(GridTypeDims.VERTEX.value).issubset(ds.dims)
+    return GridTypeDims.parse_dims(ds) in (
+        GridTypeDims.VERTEX,
+        GridTypeDims.VERTEX_LAYERED,
+    )
 
 
 def is_layered(ds):

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -1561,9 +1561,9 @@ def aggregate_vector_per_cell(gdf, fields_methods, modelgrid=None):
         else:
             raise TypeError("cannot aggregate geometries of different types")
     if bool({"length_weighted", "max_length"} & set(fields_methods.values())):
-        assert geom_types[0] == "LineString", (
-            "can only use length methods with line geometries"
-        )
+        assert (
+            geom_types[0] == "LineString"
+        ), "can only use length methods with line geometries"
     if bool({"area_weighted", "max_area"} & set(fields_methods.values())):
         if ("Polygon" in geom_types) or ("MultiPolygon" in geom_types):
             pass

--- a/nlmod/dims/grid.py
+++ b/nlmod/dims/grid.py
@@ -36,9 +36,57 @@ from .layers import (
     remove_inactive_layers,
 )
 from .rdp import rdp
-from .shared import get_area, get_delc, get_delr  # noqa: F401
+from .shared import GridTypeDims, get_area, get_delc, get_delr  # noqa: F401
 
 logger = logging.getLogger(__name__)
+
+
+def is_structured(ds):
+    """Check if a dataset is structured.
+
+    Parameters
+    ----------
+    ds : xr.Dataset or xr.Dataarray
+        dataset or dataarray
+
+    Returns
+    -------
+    bool
+        True if the dataset is structured.
+    """
+    return set(GridTypeDims.STRUCTURED.value).issubset(ds.dims)
+
+
+def is_vertex(ds):
+    """Check if a dataset is vertex.
+
+    Parameters
+    ----------
+    ds : xr.Dataset or xr.Dataarray
+        dataset or dataarray
+
+    Returns
+    -------
+    bool
+        True if the dataset is structured.
+    """
+    return set(GridTypeDims.VERTEX.value).issubset(ds.dims)
+
+
+def is_layered(ds):
+    """Check if a dataset is layered.
+
+    Parameters
+    ----------
+    ds : xr.Dataset or xr.Dataarray
+        dataset or dataarray
+
+    Returns
+    -------
+    bool
+        True if the dataset is layered.
+    """
+    return "layer" in ds.dims
 
 
 def snap_extent(extent, delr, delc):

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -472,6 +472,39 @@ def sum_param_combined_layers(da, reindexer):
     return da_new
 
 
+def _get_empty_layered_da(da, nlay):
+    """Get empty DataArray with number of layer specified by nlay.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        original data array
+    nlay : int
+        number of layers
+
+    Returns
+    -------
+    da_new : xarray.DataArray
+        new empty data array with updated number of layers
+    """
+    if set(GridTypeDims.STRUCTURED_LAYERED.value).issubset(da.dims):
+        dims = GridTypeDims.STRUCTURED_LAYERED.value
+        coords = {
+            "layer": np.arange(nlay),
+            "y": da["y"],
+            "x": da["x"],
+        }
+    elif set(GridTypeDims.VERTEX_LAYERED.value).issubset(da.dims):
+        dims = GridTypeDims.VERTEX_LAYERED.value
+        coords = {
+            "layer": np.arange(nlay),
+            "icell2d": da["icell2d"],
+        }
+    else:
+        raise TypeError("Cannot determine grid type of data array.")
+    return xr.DataArray(data=np.nan, dims=dims, coords=coords)
+
+
 def kheq_combined_layers(kh, thickness, reindexer):
     """Calculate equivalent horizontal hydraulic conductivity.
 

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -270,9 +270,9 @@ def split_layers_ds(
             split_dict[lay0] = [1 / split_dict[lay0]] * split_dict[lay0]
         elif hasattr(split_dict[lay0], "__iter__"):
             # make sure the fractions add up to 1
-            assert np.isclose(np.sum(split_dict[lay0]), 1), (
-                f"Fractions for splitting layer '{lay0}' do not add up to 1."
-            )
+            assert np.isclose(
+                np.sum(split_dict[lay0]), 1
+            ), f"Fractions for splitting layer '{lay0}' do not add up to 1."
             split_dict[lay0] = split_dict[lay0] / np.sum(split_dict[lay0])
         else:
             raise ValueError(

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -6,6 +6,7 @@ import xarray as xr
 
 from ..util import LayerError, _get_value_from_ds_datavar
 from .resample import fillnan_da
+from .shared import GridTypeDims
 
 logger = logging.getLogger(__name__)
 

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -562,6 +562,7 @@ def combine_layers_ds(
     kv="kv",
     kD="kD",
     c="c",
+    return_reindexer=False,
 ):
     """Combine layers in Dataset.
 
@@ -593,6 +594,9 @@ def combine_layers_ds(
     c : str, optional
         name of data variable containg resistance or c,
         by default 'c'. Not parsed if set to None.
+    return_reindexer : bool, optional
+        Return a dictionary that can be used to reindex variables from the original
+        layer-dimension to the new layer-dimension when True. The default is False.
 
     Returns
     -------
@@ -727,21 +731,19 @@ def combine_layers_ds(
     for k, da in da_dict.items():
         da_dict[k] = da.assign_coords(layer=layer_names)
 
-    # add reindexer to attributes
-    attrs = ds.attrs.copy()
-    attrs["combine_reindexer"] = reindexer
-
     # add original data variables to new dataset
     for dv in keep_dv:
         da_dict[dv] = ds[dv]
 
     # create new dataset
     logger.info("Done! Created new dataset with combined layers!")
-    ds_combine = xr.Dataset(da_dict, attrs=attrs)
+    ds_combine = xr.Dataset(da_dict, attrs=ds.attrs)
 
     # remove layer dimension from top
     ds_combine = remove_layer_dim_from_top(ds_combine, inconsistency_threshold=1e-5)
 
+    if return_reindexer:
+        return ds_combine, reindexer
     return ds_combine
 
 

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -375,18 +375,9 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
     new_nlay = (
         ds[layer].size - sum((len(c) for c in combine_layers)) + len(combine_layers)
     )
-
     # create new DataArrays for storing new top/bot
-    new_bot = xr.DataArray(
-        data=np.nan,
-        dims=["layer", "y", "x"],
-        coords={"layer": np.arange(new_nlay), "y": ds.y.data, "x": ds.x.data},
-    )
-    new_top = xr.DataArray(
-        data=np.nan,
-        dims=["layer", "y", "x"],
-        coords={"layer": np.arange(new_nlay), "y": ds.y.data, "x": ds.x.data},
-    )
+    new_bot = _get_empty_layered_da(ds[bot], nlay=new_nlay)
+    new_top = _get_empty_layered_da(ds[top], nlay=new_nlay)
 
     # dict to keep track of old and new layer indices
     reindexer = {}
@@ -453,16 +444,7 @@ def sum_param_combined_layers(da, reindexer):
         data array containing new parameters for combined layers and old
         parameters for unmodified layers.
     """
-    da_new = xr.DataArray(
-        data=np.nan,
-        dims=["layer", "y", "x"],
-        coords={
-            "layer": np.arange(list(reindexer.keys())[-1] + 1),
-            "y": da["y"],
-            "x": da["x"],
-        },
-    )
-
+    da_new = _get_empty_layered_da(da, nlay=list(reindexer.keys())[-1] + 1)
     for k, v in reindexer.items():
         if isinstance(v, tuple):
             psum = np.sum(da.data[v, :, :], axis=0)
@@ -524,16 +506,7 @@ def kheq_combined_layers(kh, thickness, reindexer):
         for combined layers and original hydraulic conductivity in unmodified
         layers
     """
-    da_kh = xr.DataArray(
-        data=np.nan,
-        dims=["layer", "y", "x"],
-        coords={
-            "layer": np.arange(list(reindexer.keys())[-1] + 1),
-            "y": kh["y"],
-            "x": kh["x"],
-        },
-    )
-
+    da_kh = _get_empty_layered_da(kh, nlay=list(reindexer.keys())[-1] + 1)
     for k, v in reindexer.items():
         if isinstance(v, tuple):
             kheq = np.nansum(
@@ -565,16 +538,7 @@ def kveq_combined_layers(kv, thickness, reindexer):
         for combined layers and original hydraulic conductivity in unmodified
         layers
     """
-    da_kv = xr.DataArray(
-        data=np.nan,
-        dims=["layer", "y", "x"],
-        coords={
-            "layer": np.arange(list(reindexer.keys())[-1] + 1),
-            "y": kv["y"],
-            "x": kv["x"],
-        },
-    )
-
+    da_kv = _get_empty_layered_da(kv, nlay=list(reindexer.keys())[-1] + 1)
     for k, v in reindexer.items():
         if isinstance(v, tuple):
             kveq = np.nansum(thickness.data[v, :, :], axis=0) / np.nansum(

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -402,7 +402,7 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
                         "calculate new top/bot."
                     )
                 tops = ds[top].data[c, ...]
-                bots = ds[bot].data[c, :, :]
+                bots = ds[bot].data[c, ...]
                 new_top.data[j] = np.nanmax(tops, axis=0)
                 new_bot.data[j] = np.nanmin(bots, axis=0)
 
@@ -447,7 +447,7 @@ def sum_param_combined_layers(da, reindexer):
     da_new = _get_empty_layered_da(da, nlay=list(reindexer.keys())[-1] + 1)
     for k, v in reindexer.items():
         if isinstance(v, tuple):
-            psum = np.sum(da.data[v, :, :], axis=0)
+            psum = np.sum(da.data[v, ...], axis=0)
         else:
             psum = da.data[v]
         da_new.data[k] = psum
@@ -510,8 +510,8 @@ def kheq_combined_layers(kh, thickness, reindexer):
     for k, v in reindexer.items():
         if isinstance(v, tuple):
             kheq = np.nansum(
-                thickness.data[v, :, :] * kh.data[v, :, :], axis=0
-            ) / np.nansum(thickness.data[v, :, :], axis=0)
+                thickness.data[v, ...] * kh.data[v, ...], axis=0
+            ) / np.nansum(thickness.data[v, ...], axis=0)
             kheq[np.isinf(kheq)] = np.nan
         else:
             kheq = kh.data[v]
@@ -541,8 +541,8 @@ def kveq_combined_layers(kv, thickness, reindexer):
     da_kv = _get_empty_layered_da(kv, nlay=list(reindexer.keys())[-1] + 1)
     for k, v in reindexer.items():
         if isinstance(v, tuple):
-            kveq = np.nansum(thickness.data[v, :, :], axis=0) / np.nansum(
-                thickness.data[v, :, :] / kv.data[v, :, :], axis=0
+            kveq = np.nansum(thickness.data[v, ...], axis=0) / np.nansum(
+                thickness.data[v, ...] / kv.data[v, ...], axis=0
             )
             kveq[np.isinf(kveq)] = np.nan
         else:

--- a/nlmod/dims/shared.py
+++ b/nlmod/dims/shared.py
@@ -12,11 +12,23 @@ class GridTypeDims(Enum):
     STRUCTURED = ("y", "x")
     VERTEX = ("icell2d",)
 
+    @classmethod
+    def parse_dims(cls, ds):
+        """Get GridTypeDim from dataset or dataarray.
+
+        Parameters
+        ----------
+        ds : xr.Dataset or xr.DataArray
+            Dataset or DataArray to parse.
+        """
+        for gridtype in GridTypeDims:
+            if set(gridtype.value).issubset(ds.dims):
+                return gridtype
+
 
 def get_delr(ds):
     """
-    Get the distance along rows (delr) from the x-coordinate of a structured model
-    dataset.
+    Get the distance along rows (delr) from the x-coordinate of a structured model ds.
 
     Parameters
     ----------

--- a/nlmod/dims/shared.py
+++ b/nlmod/dims/shared.py
@@ -1,5 +1,16 @@
+from enum import Enum
+
 import numpy as np
 import xarray as xr
+
+
+class GridTypeDims(Enum):
+    """Enum for grid dimensions."""
+
+    STRUCTURED_LAYERED = ("layer", "y", "x")
+    VERTEX_LAYERED = ("layer", "icell2d")
+    STRUCTURED = ("y", "x")
+    VERTEX = ("icell2d",)
 
 
 def get_delr(ds):

--- a/nlmod/dims/shared.py
+++ b/nlmod/dims/shared.py
@@ -20,10 +20,22 @@ class GridTypeDims(Enum):
         ----------
         ds : xr.Dataset or xr.DataArray
             Dataset or DataArray to parse.
+
+        Returns
+        -------
+        gridtype : GridTypeDims
+            type of grid
+        
+        Raises
+        ------
+        ValueError
+            If no partially matching gridtype is found.
         """
         for gridtype in GridTypeDims:
             if set(gridtype.value).issubset(ds.dims):
                 return gridtype
+        # raises ValueError if no gridtype is found
+        return cls(ds.dims)
 
 
 def get_delr(ds):

--- a/nlmod/dims/shared.py
+++ b/nlmod/dims/shared.py
@@ -25,7 +25,7 @@ class GridTypeDims(Enum):
         -------
         gridtype : GridTypeDims
             type of grid
-        
+
         Raises
         ------
         ValueError

--- a/nlmod/dims/time.py
+++ b/nlmod/dims/time.py
@@ -707,9 +707,9 @@ def dataframe_to_flopy_timeseries(
     append=False,
 ):
     assert not df.isna().any(axis=None)
-    assert ds.time.dtype.kind == "M", (
-        "get recharge requires a datetime64[ns] time index"
-    )
+    assert (
+        ds.time.dtype.kind == "M"
+    ), "get recharge requires a datetime64[ns] time index"
     if ds is not None:
         # set index to days after the start of the simulation
         df = df.copy()

--- a/nlmod/gis.py
+++ b/nlmod/gis.py
@@ -47,9 +47,9 @@ def vertex_da_to_gdf(
     gdf : geopandas.GeoDataframe
         geodataframe of one or more DataArrays.
     """
-    assert model_ds.gridtype == "vertex", (
-        f"expected model dataset with gridtype vertex, got {model_ds.gridtype}"
-    )
+    assert (
+        model_ds.gridtype == "vertex"
+    ), f"expected model dataset with gridtype vertex, got {model_ds.gridtype}"
 
     if isinstance(data_variables, str):
         data_variables = [data_variables]
@@ -126,9 +126,9 @@ def struc_da_to_gdf(
     gdf : geopandas.GeoDataframe
         geodataframe of one or more DataArrays.
     """
-    assert model_ds.gridtype == "structured", (
-        f"expected model dataset with gridtype vertex, got {model_ds.gridtype}"
-    )
+    assert (
+        model_ds.gridtype == "structured"
+    ), f"expected model dataset with gridtype vertex, got {model_ds.gridtype}"
 
     if isinstance(data_variables, str):
         data_variables = [data_variables]

--- a/nlmod/gwf/horizontal_flow_barrier.py
+++ b/nlmod/gwf/horizontal_flow_barrier.py
@@ -38,9 +38,9 @@ def get_hfb_spd(gwf, linestrings, hydchr=1 / 100, depth=None, elevation=None):
     spd : List of Tuple
         Stress period data used to configure the hfb package of Flopy.
     """
-    assert sum([depth is None, elevation is None]) == 1, (
-        "Use either depth or elevation argument"
-    )
+    assert (
+        sum([depth is None, elevation is None]) == 1
+    ), "Use either depth or elevation argument"
 
     tops = np.concatenate((gwf.disv.top.array[None], gwf.disv.botm.array))
     thick = tops[:-1] - tops[1:]

--- a/nlmod/read/rws.py
+++ b/nlmod/read/rws.py
@@ -7,7 +7,7 @@ import geopandas as gpd
 import numpy as np
 import xarray as xr
 from rioxarray.merge import merge_arrays
-from tqdm.auto import tqdm
+from tqdm import tqdm
 
 from nlmod import NLMOD_DATADIR, cache, dims, util
 from nlmod.read import jarkus

--- a/tests/test_006_caching.py
+++ b/tests/test_006_caching.py
@@ -10,20 +10,20 @@ def test_cache_ahn_data_array():
     cache_name = "ahn4.nc"
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        assert not os.path.exists(os.path.join(tmpdir, cache_name)), (
-            "Cache should not exist yet1"
-        )
+        assert not os.path.exists(
+            os.path.join(tmpdir, cache_name)
+        ), "Cache should not exist yet1"
         ahn_no_cache = nlmod.read.ahn.get_ahn4(extent)
-        assert not os.path.exists(os.path.join(tmpdir, cache_name)), (
-            "Cache should not exist yet2"
-        )
+        assert not os.path.exists(
+            os.path.join(tmpdir, cache_name)
+        ), "Cache should not exist yet2"
 
         ahn_cached = nlmod.read.ahn.get_ahn4(
             extent, cachedir=tmpdir, cachename=cache_name
         )
-        assert os.path.exists(os.path.join(tmpdir, cache_name)), (
-            "Cache should have existed by now"
-        )
+        assert os.path.exists(
+            os.path.join(tmpdir, cache_name)
+        ), "Cache should have existed by now"
         assert ahn_cached.equals(ahn_no_cache)
         modification_time1 = os.path.getmtime(os.path.join(tmpdir, cache_name))
 
@@ -41,9 +41,9 @@ def test_cache_ahn_data_array():
             extent, cachedir=tmpdir, cachename=cache_name
         )
         modification_time3 = os.path.getmtime(os.path.join(tmpdir, cache_name))
-        assert modification_time1 != modification_time3, (
-            "Cache should have been rewritten"
-        )
+        assert (
+            modification_time1 != modification_time3
+        ), "Cache should have been rewritten"
 
 
 def test_cache_northsea_data_array():
@@ -72,18 +72,18 @@ def test_cache_northsea_data_array():
     cache_name = "northsea.nc"
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        assert not os.path.exists(os.path.join(tmpdir, cache_name)), (
-            "Cache should not exist yet1"
-        )
+        assert not os.path.exists(
+            os.path.join(tmpdir, cache_name)
+        ), "Cache should not exist yet1"
         out1_no_cache = get_northsea(ds1)
-        assert not os.path.exists(os.path.join(tmpdir, cache_name)), (
-            "Cache should not exist yet2"
-        )
+        assert not os.path.exists(
+            os.path.join(tmpdir, cache_name)
+        ), "Cache should not exist yet2"
 
         out1_cached = get_northsea(ds1, cachedir=tmpdir, cachename=cache_name)
-        assert os.path.exists(os.path.join(tmpdir, cache_name)), (
-            "Cache should exist by now"
-        )
+        assert os.path.exists(
+            os.path.join(tmpdir, cache_name)
+        ), "Cache should exist by now"
         assert out1_cached.equals(out1_no_cache)
         modification_time1 = os.path.getmtime(os.path.join(tmpdir, cache_name))
 
@@ -103,7 +103,7 @@ def test_cache_northsea_data_array():
         # Different extent should not lead to using the cache
         out2_cache = get_northsea(ds2, cachedir=tmpdir, cachename=cache_name)
         modification_time3 = os.path.getmtime(os.path.join(tmpdir, cache_name))
-        assert modification_time1 != modification_time3, (
-            "Cache should have been rewritten"
-        )
+        assert (
+            modification_time1 != modification_time3
+        ), "Cache should have been rewritten"
         assert not out2_cache.equals(out1_no_cache)

--- a/tests/test_008_waterschappen.py
+++ b/tests/test_008_waterschappen.py
@@ -1,7 +1,9 @@
-import matplotlib
-import pytest
-import numpy as np
 import os
+
+import matplotlib
+import numpy as np
+import pytest
+
 import nlmod
 
 # def test_download_polygons(): # is tested in test_024_administrative.test_get_waterboards


### PR DESCRIPTION
Allow combining layers in vertex datasets.

Add methods to check dataset or dataarray type:
- ` nlmod.grid.is_structured(ds)` 
- ` nlmod.grid.is_vertex(ds)` 
- ` nlmod.grid.is_layered(ds)` 

Added a `GridTypeDims` enum that specifies the dimensions for different grid types. Perhaps this and the above methods can be used across nlmod for consistency in how we check for different types of inputs. But that is best left to another PR if we agree this is the way to go. 