### PR TITLE
check if 'layer' dimension is in cached dataset

### DIFF
--- a/nlmod/cache.py
+++ b/nlmod/cache.py
@@ -234,7 +234,7 @@ def cache_netcdf(
 
                     if dataset is not None:
                         # fix layer dtype if necessary
-                        if "layer" in dataset.coords:
+                        if "layer" in cached_ds.coords:
                             if dataset["layer"].dtype != cached_ds["layer"].dtype:
                                 # cached layer dtype might be read as fixed width dtype
                                 # modify dataset dtype to make hashes match


### PR DESCRIPTION
Check if the 'layer' dimension is available in the cached dataset (and not in the dataset function argument). Solves issue #467.