### PR TITLE
Remove bounds from merge_arrays, and use a slice before

### DIFF
--- a/nlmod/read/ahn.py
+++ b/nlmod/read/ahn.py
@@ -58,7 +58,9 @@ def download_ahn(
         DataArray with the ahn variable.
     """
 
-    ahn_da = _download_ahn_ellipsis(extent, identifier=identifier, merge_tiles=merge_tiles, **kwargs)
+    ahn_da = _download_ahn_ellipsis(
+        extent, identifier=identifier, merge_tiles=merge_tiles, **kwargs
+    )
     if not merge_tiles:
         return ahn_da
 
@@ -161,8 +163,9 @@ def get_ahn(
     if extent is None and ds is not None:
         extent = get_extent(ds)
 
-    ahn_da = download_ahn(extent=extent, identifier=identifier, merge_tiles=merge_tiles, 
-                          **kwargs)
+    ahn_da = download_ahn(
+        extent=extent, identifier=identifier, merge_tiles=merge_tiles, **kwargs
+    )
     # this is probably redundant when we have the 'download_ahn' function
     if not merge_tiles:
         return ahn_da
@@ -1317,13 +1320,14 @@ def _download_ahn_ellipsis(
             da = rioxarray.open_rasterio(f"zip+{url}!/{path}", mask_and_scale=True)
         else:
             da = rioxarray.open_rasterio(url, mask_and_scale=True)
+        da = da.sel(x=slice(extent[0], extent[1]), y=slice(extent[3], extent[2]))
         das.append(da)
 
     if len(das) == 0:
         raise (ValueError("No data found within extent"))
 
     if merge_tiles:
-        da = merge_arrays(das, bounds=(extent[0], extent[2], extent[1], extent[3]))
+        da = merge_arrays(das)
         if da.dims[0] == "band":
             da = da[0].drop_vars("band")
         if "_FillValue" in da.attrs:


### PR DESCRIPTION
As @OnnoEbbens found out, using the bounds argument in rioxarray.merge.merge_arrays produces strange results. This can also be see in https://nlmod.readthedocs.io/en/latest/examples/11_grid_rotation.html#Add-AHN:
![image](https://github.com/user-attachments/assets/1129a758-183b-4228-9695-6f5ad9c12286)


Therefore, we revert back to the way we used to merge the ahn-tiles (which is still in the main-branch), where we use a slice just after downloading.