### PR TITLE
make get_modellayers_indexer more robust to real-world data

### DIFF
--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -2346,10 +2346,14 @@ def get_modellayers_indexer(
     if npts_outside_domain > 0:
         maskpts = ~pts_to_cellid.isna()
         pts = pts[maskpts]
-        df = df.loc[maskpts].copy()
+        pts_to_cellid  = pts_to_cellid[maskpts]
+        df = df.loc[maskpts.values].copy()
         logger.warning(
             "Warning! Dropped %d points outside the model domain.", npts_outside_domain
         )
+
+    # ensure result is integer, should not contain nans after masking pts outside domain
+    pts_to_cellid = pts_to_cellid.astype(int)
 
     # build obs dataset
     rename_dict = {


### PR DESCRIPTION
- force integer dtype after removing NaNs
- use boolean array instead of series