### PR TITLE
Empty lakeout column leads error in lake package construction

### DIFF
--- a/nlmod/gwf/lake.py
+++ b/nlmod/gwf/lake.py
@@ -201,7 +201,7 @@ def lake_from_gdf(
             iconn += 1
 
         # add outlets to lake
-        if not lake_gdf["lakeout"].isna().all():
+        if "lakeout" in lake_gdf.columns and not lake_gdf["lakeout"].isna().all():
             lakeout = _get_and_check_single_value(lake_gdf, "lakeout")
             if isinstance(lakeout, str):
                 # when lakeout is a string, it represents the boundname


### PR DESCRIPTION
Lakeout column in gdf may be empty when after discretizing your lake shapes, the shapes with a valid lakeout may be outside of your extent.