### PR TITLE
Remove ecmwflibs from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ full = [
     "pyshp>=2.1.3",
 ]
 knmi = ["h5netcdf", "h5py", "nlmod[grib]"]
-grib = ["cfgrib", "ecmwflibs"]
+grib = ["cfgrib"]
 test = ["pytest>=7", "pytest-cov", "lxml"]
 nbtest = ["nbformat", "nbconvert>6.4.5"]
 lint = ["ruff"]


### PR DESCRIPTION
ecmwflibs is not available for python 3.12 or newer, therefore it may be better to remove the dependency