### PR TITLE
Improve tests and notebooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         python-version: [3.11]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,10 +11,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 

--- a/.gitignore
+++ b/.gitignore
@@ -147,14 +147,18 @@ nlmod/bin/*
 !nlmod/bin/mp7_2_002_provisional
 nlmod/data/bofek/*
 
-tests/data/*
-!tests/data/**/
-tests/data/mfoutput/*
-!tests/data/mfoutput/vertex/*
-!tests/data/mfoutput/structured/*
-
 docs/examples/*/
 !docs/examples/data/
 !docs/examples/data/chloride_hbossche.nc
 
 docs/data_sources/*
+
+docs/advanced_stress_packages/01_lake/
+docs/advanced_stress_packages/model17/
+
+# Notebook-generated model directories (named like notebook stems, e.g. 01_lake)
+docs/advanced_stress_packages/[0-9][0-9]_*/
+docs/data_sources/[0-9][0-9]_*/
+docs/examples/[0-9][0-9]_*/
+docs/utilities/[0-9][0-9]_*/
+docs/workflows/[0-9][0-9]_*/

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,13 +1,91 @@
-/* --- Make pandas DataFrames scrollable --- */
-.dataframe {
-    max-width: 100%;      /* Prevent table from exceeding container width */
-    display: block;       /* Enables scrolling */
-    overflow-x: auto;     /* Horizontal scroll for wide tables */
+/* ---------------------------------------------
+   Documentation-style pandas dataframe tables
+   Compatible with Sphinx RTD theme + MyST-NB
+--------------------------------------------- */
+
+table.dataframe {
+  border-collapse: collapse;
+  border: none;
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
+  font-size: 0.7em;
+  margin-top: 0.4em;
+  margin-bottom: 0.6em;
 }
 
-/* make text smaller so more fits */
-.dataframe td, 
-.dataframe th {
-    font-size: 0.7em;
-    padding: 0.3em 0.5em;
+/* Column headers */
+table.dataframe thead th {
+  text-align: right;
+  padding: 4px 8px;
+  font-weight: bold;
+  border: none;
+  border-bottom: 2px solid #888; /* single horizontal line */
+  background: transparent;
+  white-space: nowrap;
+  vertical-align: bottom;
+  line-height: 1.2;
+}
+
+/* Remove empty header cells from multi-index (top-left corner) */
+table.dataframe thead th:empty {
+  padding: 0;
+  border: none;
+}
+
+/* Index columns */
+table.dataframe tbody th {
+  text-align: right;
+  padding: 4px 8px;
+  font-weight: bold;
+  border: none; /* remove all vertical borders */
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+/* Only the rightmost index column gets the vertical line */
+table.dataframe tbody th:last-of-type {
+  border-right: 1px solid #bbb;
+}
+
+/* Data cells */
+table.dataframe td {
+  text-align: right;
+  padding: 4px 8px;
+  border: none;
+  line-height: 1.2;
+}
+
+/* Zebra striping */
+table.dataframe tbody tr:nth-child(odd) {
+  background-color: #f5f5f5;
+}
+
+table.dataframe tbody tr:nth-child(even) {
+  background-color: transparent;
+}
+
+/* Hover highlight */
+table.dataframe tbody tr:hover {
+  background-color: #dcdcdc;
+}
+
+/* Multi-index column headers: only bottom row gets horizontal line */
+table.dataframe thead tr:not(:last-child) th {
+  border-bottom: none;
+}
+table.dataframe thead tr:last-child th {
+  border-bottom: 2px solid #888;
+}
+
+/* Notebook-like output container */
+div.output_area table.dataframe {
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+/* Space around notebook outputs */
+div.output_area {
+  padding: 0.35em 0;
 }

--- a/docs/advanced_stress_packages/17_unsaturated_zone_flow.ipynb
+++ b/docs/advanced_stress_packages/17_unsaturated_zone_flow.ipynb
@@ -64,7 +64,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_name = model_ws = \"model17\"\n",
+    "model_name = \"model17\"\n",
+    "model_ws = \"17_unsaturated_zone_flow\"\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)"
    ]
   },

--- a/docs/advanced_stress_packages/17_unsaturated_zone_flow.ipynb
+++ b/docs/advanced_stress_packages/17_unsaturated_zone_flow.ipynb
@@ -380,7 +380,7 @@
     "col = 0\n",
     "\n",
     "f, ax = plt.subplot_mosaic(\n",
-    "    [[\"P\"], [\"WC\"], [\"H\"]], figsize=(10, 8), height_ratios=[2, 5, 3], sharex=True\n",
+    "    [[\"P\"], [\"WC\"], [\"H\"]], figsize=(10, 8), height_ratios=[2, 5, 3], sharex=True, layout=\"constrained\"\n",
     ")\n",
     "\n",
     "# top ax\n",
@@ -411,9 +411,7 @@
     "ax[\"H\"].plot(s.index, s.values, color=\"C0\", linestyle=\"-\", label=\"GWL UZF\")\n",
     "ax[\"H\"].set_ylabel(\"z [m NAP]\")\n",
     "ax[\"H\"].legend(loc=(0, 0.98), ncol=2, frameon=False)\n",
-    "ax[\"H\"].grid()\n",
-    "\n",
-    "f.tight_layout(pad=0.8)"
+    "ax[\"H\"].grid()"
    ]
   }
  ],

--- a/docs/data_sources/02_surface_water.ipynb
+++ b/docs/data_sources/02_surface_water.ipynb
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "model_name = \"steady\"\n",
-    "model_ws = \"schoonhoven\"\n",
+    "model_ws = \"02_surface_water\"\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)\n",
     "extent = [116_500, 120_000, 439_000, 442_000]"
    ]

--- a/docs/examples/00_model_from_scratch.ipynb
+++ b/docs/examples/00_model_from_scratch.ipynb
@@ -80,7 +80,7 @@
     "    botm=botm,\n",
     "    kh=kh,\n",
     "    kv=kv,\n",
-    "    model_ws=\"./scratch_model\",\n",
+    "    model_ws=\"00_model_from_scratch\",\n",
     "    model_name=\"from_scratch\",\n",
     ")\n",
     "ds"

--- a/docs/examples/01_basic_model.ipynb
+++ b/docs/examples/01_basic_model.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "# model settings\n",
-    "model_ws = \"ijmuiden\"\n",
+    "model_ws = \"01_basic_model\"\n",
     "model_name = \"IJmuiden\"\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)\n",
     "extent = [95000.0, 105000.0, 494000.0, 500000.0]\n",

--- a/docs/examples/03_local_grid_refinement.ipynb
+++ b/docs/examples/03_local_grid_refinement.ipynb
@@ -45,7 +45,7 @@
    "outputs": [],
    "source": [
     "# model settings vertex\n",
-    "model_ws = \"ijmuiden\"\n",
+    "model_ws = \"03_local_grid_refinement\"\n",
     "model_name = \"IJm_planeten\"\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)\n",
     "refine_shp_fname = os.path.abspath(os.path.join(\"data\", \"planetenweg_ijmuiden\"))\n",

--- a/docs/examples/09_schoonhoven.ipynb
+++ b/docs/examples/09_schoonhoven.ipynb
@@ -543,15 +543,14 @@
     "x = 118228.0\n",
     "line = [(x, 439000), (x, 442000)]\n",
     "\n",
-    "f, ax = plt.subplots(figsize=(10, 6))\n",
+    "f, ax = plt.subplots(figsize=(10, 6), layout=\"constrained\")\n",
     "dcs = DatasetCrossSection(ds, line, ax=ax, zmin=-100.0, zmax=10.0)\n",
     "pc = dcs.plot_array(head.mean(\"time\"), norm=norm, head=head.mean(\"time\"))\n",
     "\n",
     "# add labels with layer names\n",
     "cbar = nlmod.plot.colorbar_inside(pc)\n",
     "dcs.plot_grid()\n",
-    "dcs.plot_layers(colors=\"none\", min_label_area=1000)\n",
-    "f.tight_layout(pad=0.0)"
+    "dcs.plot_layers(colors=\"none\", min_label_area=1000)"
    ]
   },
   {
@@ -840,7 +839,7 @@
     "        segments.extend(get_segments(x, pf[\"z\"]))\n",
     "        array.extend(get_array(pf[\"time\"]))\n",
     "\n",
-    "f, ax = plt.subplots(figsize=(10, 6))\n",
+    "f, ax = plt.subplots(figsize=(10, 6), layout=\"constrained\")\n",
     "ax.grid()\n",
     "dcs = DatasetCrossSection(ds, line, ax=ax, zmin=-100.0, zmax=10.0)\n",
     "lc = matplotlib.collections.LineCollection(\n",
@@ -851,8 +850,7 @@
     "# add grid\n",
     "dcs.plot_grid()\n",
     "# add labels with layer names\n",
-    "dcs.plot_layers(alpha=0.0, min_label_area=1000)\n",
-    "f.tight_layout(pad=0.0)"
+    "dcs.plot_layers(alpha=0.0, min_label_area=1000)"
    ]
   }
  ],

--- a/docs/examples/09_schoonhoven.ipynb
+++ b/docs/examples/09_schoonhoven.ipynb
@@ -59,7 +59,7 @@
    "outputs": [],
    "source": [
     "model_name = \"Schoonhoven\"\n",
-    "model_ws = os.path.join(\"..\", \"data_sources\", \"schoonhoven\")\n",
+    "model_ws = \"09_schoonhoven\"\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)\n",
     "extent = [116_500, 120_000, 439_000, 442_000]\n",
     "time = pd.date_range(\"2020\", \"2023\", freq=\"MS\")  # monthly timestep"
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fname_bgt = os.path.join(cachedir, \"bgt.gpkg\")\n",
+    "fname_bgt = os.path.join(\"..\", \"data_sources\", \"02_surface_water\", \"cache\", \"bgt.gpkg\")\n",
     "if not os.path.isfile(fname_bgt):\n",
     "    raise (\n",
     "        Exception(\n",
@@ -857,22 +857,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/examples/14_stromingen_example.ipynb
+++ b/docs/examples/14_stromingen_example.ipynb
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "# define a model workspace for caching downloaded data\n",
-    "model_ws = os.path.join(\"..\", \"data_sources\", \"schoonhoven\")\n",
+    "model_ws = \"14_stromingen_example\"\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)"
    ]
   },
@@ -113,7 +113,7 @@
     "# wells = nlmod.read.get_wells(extent)  # no well data is available just yet\n",
     "\n",
     "# surface water features and levels\n",
-    "fname_bgt = os.path.join(cachedir, \"bgt.gpkg\")\n",
+    "fname_bgt = os.path.join(\"..\", \"data_sources\", \"02_surface_water\", \"cache\", \"bgt.gpkg\")\n",
     "if not os.path.isfile(fname_bgt):\n",
     "    raise (\n",
     "        Exception(\n",

--- a/docs/examples/16_groundwater_transport.ipynb
+++ b/docs/examples/16_groundwater_transport.ipynb
@@ -56,7 +56,7 @@
    "outputs": [],
    "source": [
     "# model settings\n",
-    "model_ws = \"hondsbossche\"\n",
+    "model_ws = \"16_groundwater_transport\"\n",
     "model_name = \"hondsbossche\"\n",
     "\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)\n",

--- a/docs/examples/16_groundwater_transport.ipynb
+++ b/docs/examples/16_groundwater_transport.ipynb
@@ -72,7 +72,7 @@
     "start_time = \"2010-1-1\"\n",
     "starting_head = 1.0\n",
     "\n",
-    "municipalities = nlmod.read.administrative.get_municipalities(extent=extent_hbossche)"
+    "municipalities = nlmod.read.administrative.download_municipalities(extent=extent_hbossche)"
    ]
   },
   {

--- a/docs/utilities/05_caching.ipynb
+++ b/docs/utilities/05_caching.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_ws = \"model5\"\n",
+    "model_ws = \"05_caching\"\n",
     "\n",
     "# Model directories\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)\n",

--- a/docs/utilities/06_gridding_vector_data.ipynb
+++ b/docs/utilities/06_gridding_vector_data.ipynb
@@ -53,7 +53,7 @@
     "ds = nlmod.get_ds([950, 1250, 20050, 20350], delr=100)\n",
     "# vertex grid\n",
     "dsv = nlmod.grid.refine(\n",
-    "    ds, refinement_features=[([Point(1200, 20200)], \"point\", 1)], model_ws=\"model7\"\n",
+    "    ds, refinement_features=[([Point(1200, 20200)], \"point\", 1)], model_ws=\"06_gridding_vector_data\"\n",
     ")"
    ]
   },

--- a/docs/utilities/07_resampling.ipynb
+++ b/docs/utilities/07_resampling.ipynb
@@ -65,12 +65,13 @@
    "outputs": [],
    "source": [
     "ds = nlmod.get_ds([950, 1250, 20050, 20350], delr=100)\n",
-    "rng = np.random.default_rng(12345)\n",
+    "rng = np.random.default_rng(123)\n",
     "ds[\"data\"] = (\"y\", \"x\"), rng.random((len(ds.y), len(ds.x))) * 10\n",
     "\n",
+    "norm=Normalize(0, 10)\n",
     "fig, ax = plt.subplots()\n",
     "ax.set_aspect(\"equal\")\n",
-    "ds[\"data\"].plot(ax=ax, lw=0.1, edgecolor=\"k\");"
+    "ds[\"data\"].plot(ax=ax, lw=0.1, edgecolor=\"k\", norm=norm);"
    ]
   },
   {
@@ -91,7 +92,7 @@
     "\n",
     "fig, ax = plt.subplots()\n",
     "ax.set_aspect(\"equal\")\n",
-    "ds[\"data_nan\"].plot(ax=ax, lw=0.1, edgecolor=\"k\");"
+    "ds[\"data_nan\"].plot(ax=ax, lw=0.1, edgecolor=\"k\", norm=norm);"
    ]
   },
   {
@@ -110,11 +111,12 @@
     "dsv = nlmod.grid.refine(\n",
     "    ds, refinement_features=[([Point(1200, 20200)], \"point\", 1)], model_ws=\"07_resampling\"\n",
     ")\n",
-    "dsv[\"data\"] = \"icell2d\", rng.random(len(dsv.data))\n",
+    "dsv[\"data\"] = \"icell2d\", rng.random(len(dsv.data)) * 10\n",
     "\n",
     "fig, ax = plt.subplots()\n",
     "ax.set_aspect(\"equal\")\n",
-    "nlmod.plot.data_array(dsv[\"data\"], ds=dsv, edgecolor=\"k\");"
+    "pc = nlmod.plot.data_array(dsv[\"data\"], ds=dsv, edgecolor=\"k\", norm=norm)\n",
+    "plt.colorbar(pc);"
    ]
   },
   {
@@ -135,7 +137,7 @@
     "\n",
     "fig, ax = plt.subplots()\n",
     "ax.set_aspect(\"equal\")\n",
-    "nlmod.plot.data_array(dsv[\"data_nan\"], ds=dsv, edgecolor=\"k\");"
+    "nlmod.plot.data_array(dsv[\"data_nan\"], ds=dsv, edgecolor=\"k\", norm=norm);"
    ]
   },
   {
@@ -163,10 +165,10 @@
    "source": [
     "def compare_structured_data_arrays(da1, da2, method, edgecolor=\"k\"):\n",
     "    fig, axes = plt.subplots(ncols=2, figsize=(12, 6))\n",
-    "    da1.plot(ax=axes[0], edgecolor=edgecolor, vmin=0, vmax=9)\n",
+    "    da1.plot(ax=axes[0], edgecolor=edgecolor, norm=norm)\n",
     "    axes[0].set_aspect(\"equal\")\n",
     "    axes[0].set_title(\"original grid\")\n",
-    "    da2.plot(ax=axes[1], edgecolor=edgecolor, vmin=0, vmax=9)\n",
+    "    da2.plot(ax=axes[1], edgecolor=edgecolor, norm=norm)\n",
     "    axes[1].set_aspect(\"equal\")\n",
     "    axes[1].set_title(f\"resampled grid, method {method}\")"
    ]
@@ -282,7 +284,6 @@
    "source": [
     "def compare_struct_to_vertex(struc2d, res_vertex2d_n, dsv, method):\n",
     "    fig, axes = plt.subplots(ncols=2, figsize=(12, 6))\n",
-    "    norm = Normalize(0, 9)\n",
     "    struc2d.plot(ax=axes[0], edgecolor=\"k\", norm=norm)\n",
     "    axes[0].set_aspect(\"equal\")\n",
     "    axes[0].set_title(\"structured grid\")\n",
@@ -328,7 +329,6 @@
    "source": [
     "def compare_vertex_to_struct(vertex1, dsv, struc_out_n, method):\n",
     "    fig, axes = plt.subplots(ncols=2, figsize=(12, 6))\n",
-    "    norm = Normalize(0, 9)\n",
     "    pc = nlmod.plot.data_array(vertex1, ds=dsv, ax=axes[0], edgecolor=\"k\", norm=norm)\n",
     "    plt.colorbar(pc)\n",
     "    axes[0].set_title(\"original\")\n",
@@ -416,7 +416,6 @@
    "source": [
     "def compare_vertex_arrays(vertex1, vertex2, dsv, method):\n",
     "    fig, axes = plt.subplots(ncols=2, figsize=(12, 6))\n",
-    "    norm = Normalize(0, 9)\n",
     "    pc = nlmod.plot.data_array(vertex1, ds=dsv, ax=axes[0], edgecolor=\"k\", norm=norm)\n",
     "    plt.colorbar(pc)\n",
     "    axes[0].set_title(\"original\")\n",
@@ -523,7 +522,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "norm = Normalize(ahn.min(), ahn.max())\n",
     "for method in [\"nearest\", \"average\", \"min\", \"max\"]:\n",
     "    ahn_res = nlmod.resample.structured_da_to_ds(ahn, dsv, method=method)\n",
     "\n",

--- a/docs/utilities/07_resampling.ipynb
+++ b/docs/utilities/07_resampling.ipynb
@@ -108,7 +108,7 @@
    "outputs": [],
    "source": [
     "dsv = nlmod.grid.refine(\n",
-    "    ds, refinement_features=[([Point(1200, 20200)], \"point\", 1)], model_ws=\"model7\"\n",
+    "    ds, refinement_features=[([Point(1200, 20200)], \"point\", 1)], model_ws=\"07_resampling\"\n",
     ")\n",
     "dsv[\"data\"] = \"icell2d\", rng.random(len(dsv.data))\n",
     "\n",
@@ -514,7 +514,7 @@
     "gdf = gpd.GeoDataFrame(\n",
     "    geometry=[LineString([(extent[0], extent[2]), (extent[1], extent[3])]).buffer(10.0)]\n",
     ")\n",
-    "dsv = nlmod.grid.refine(ds_ahn, model_ws=\"model7\", refinement_features=[(gdf, 1)])"
+    "dsv = nlmod.grid.refine(ds_ahn, model_ws=\"07_resampling\", refinement_features=[(gdf, 1)])"
    ]
   },
   {

--- a/docs/utilities/08_gis.ipynb
+++ b/docs/utilities/08_gis.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_ws = os.path.join(\"..\", \"examples\", \"ijmuiden\")\n",
+    "model_ws = \"08_gis\"\n",
     "model_name = \"IJmuiden\""
    ]
   },

--- a/docs/utilities/08_gis.ipynb
+++ b/docs/utilities/08_gis.ipynb
@@ -51,8 +51,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_ws = \"08_gis\"\n",
-    "model_name = \"IJmuiden\""
+    "source_ws_struc = os.path.join(\"..\", \"examples\", \"01_basic_model\")\n",
+    "model_name = \"IJmuiden\"\n",
+    "output_ws = \"08_gis\"\n",
+    "os.makedirs(output_ws, exist_ok=True)"
    ]
   },
   {
@@ -62,7 +64,7 @@
    "outputs": [],
    "source": [
     "ds_struc = xr.load_dataset(\n",
-    "    os.path.join(model_ws, f\"{model_name}.nc\"), mask_and_scale=False\n",
+    "    os.path.join(source_ws_struc, f\"{model_name}.nc\"), mask_and_scale=False\n",
     ")\n",
     "ds_struc"
    ]
@@ -74,9 +76,8 @@
    "outputs": [],
    "source": [
     "# create gisdir\n",
-    "gisdir_struc = os.path.join(model_ws, \"gis\")\n",
-    "if not os.path.exists(gisdir_struc):\n",
-    "    os.mkdir(gisdir_struc)"
+    "gisdir_struc = os.path.join(output_ws, \"structured\")\n",
+    "os.makedirs(gisdir_struc, exist_ok=True)"
    ]
   },
   {
@@ -92,6 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "source_ws_vert = os.path.join(\"..\", \"examples\", \"03_local_grid_refinement\")\n",
     "model_name = \"IJm_planeten\""
    ]
   },
@@ -102,7 +104,7 @@
    "outputs": [],
    "source": [
     "ds_vert = xr.load_dataset(\n",
-    "    os.path.join(model_ws, f\"{model_name}.nc\"), mask_and_scale=False\n",
+    "    os.path.join(source_ws_vert, f\"{model_name}.nc\"), mask_and_scale=False\n",
     ")\n",
     "ds_vert"
    ]
@@ -114,9 +116,8 @@
    "outputs": [],
    "source": [
     "# create gisdir\n",
-    "gisdir_vert = os.path.join(model_ws, \"gis\")\n",
-    "if not os.path.exists(gisdir_vert):\n",
-    "    os.mkdir(gisdir_vert)"
+    "gisdir_vert = os.path.join(output_ws, \"vertex\")\n",
+    "os.makedirs(gisdir_vert, exist_ok=True)"
    ]
   },
   {

--- a/docs/utilities/13_plot_methods.ipynb
+++ b/docs/utilities/13_plot_methods.ipynb
@@ -76,7 +76,7 @@
    "outputs": [],
    "source": [
     "model_name = \"Schoonhoven\"\n",
-    "model_ws = os.path.join(\"..\", \"data_sources\", \"schoonhoven\")\n",
+    "model_ws = os.path.join(\"..\", \"examples\", \"09_schoonhoven\")\n",
     "fname_nc = os.path.join(model_ws, f\"{model_name}.nc\")\n",
     "if not os.path.isfile(fname_nc):\n",
     "    raise (\n",
@@ -85,10 +85,8 @@
     "        )\n",
     "    )\n",
     "ds = xr.open_dataset(fname_nc)\n",
-    "\n",
-    "# add calculated heads\n",
-    "ds[\"head\"] = nlmod.gwf.get_heads_da(ds)\n",
-    "ds"
+    "ds.attrs[\"model_ws\"] = model_ws\n",
+    "ds[\"head\"] = nlmod.gwf.output.get_heads_da(ds)\n"
    ]
   },
   {
@@ -368,22 +366,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/workflows/01_layer_generation.ipynb
+++ b/docs/workflows/01_layer_generation.ipynb
@@ -114,7 +114,7 @@
    "outputs": [],
    "source": [
     "ds = nlmod.to_model_ds(regis, delr=delr, delc=delc)\n",
-    "ds = nlmod.grid.refine(ds, model_ws=\"model_12\", refinement_features=refinement_features)"
+    "ds = nlmod.grid.refine(ds, model_ws=\"01_layer_generation\", refinement_features=refinement_features)"
    ]
   },
   {
@@ -153,7 +153,7 @@
    "outputs": [],
    "source": [
     "ds = nlmod.get_ds(extent, delr=delr, delc=delc)\n",
-    "ds = nlmod.grid.refine(ds, model_ws=\"model_12\", refinement_features=refinement_features)\n",
+    "ds = nlmod.grid.refine(ds, model_ws=\"01_layer_generation\", refinement_features=refinement_features)\n",
     "ds = nlmod.grid.update_ds_from_layer_ds(ds, regis, method=\"average\")"
    ]
   },

--- a/docs/workflows/02_grid_rotation.ipynb
+++ b/docs/workflows/02_grid_rotation.ipynb
@@ -70,7 +70,7 @@
     "    yorigin=500_000,\n",
     "    delr=10.0,\n",
     "    model_name=\"nlmod\",\n",
-    "    model_ws=\"model11\",\n",
+    "    model_ws=\"02_grid_rotation\",\n",
     ")\n",
     "\n",
     "ds = nlmod.time.set_ds_time(ds, time=\"2023-01-01\", start=\"2013-01-01\")"

--- a/docs/workflows/03_aggregating_surface_water.ipynb
+++ b/docs/workflows/03_aggregating_surface_water.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "model_name = \"Schoonhoven\"\n",
-    "model_ws = os.path.join(\"..\", \"data_sources\", \"schoonhoven\")\n",
+    "model_ws = \"03_aggregating_surface_water\"\n",
     "figdir, cachedir = nlmod.util.get_model_dirs(model_ws)\n",
     "extent = [116_500, 120_000, 439_000, 442_000]\n",
     "time = pd.date_range(\"2020\", \"2023\", freq=\"MS\")  # monthly timestep"
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fname_bgt = os.path.join(cachedir, \"bgt.gpkg\")\n",
+    "fname_bgt = os.path.join(\"..\", \"data_sources\", \"02_surface_water\", \"cache\", \"bgt.gpkg\")\n",
     "if not os.path.isfile(fname_bgt):\n",
     "    raise (\n",
     "        Exception(\n",
@@ -635,22 +635,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/workflows/10_modpath.ipynb
+++ b/docs/workflows/10_modpath.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "# load lgr model dataset\n",
-    "model_ws = os.path.join(\"..\", \"examples\", \"ijmuiden\")\n",
+    "model_ws = os.path.join(\"..\", \"examples\", \"03_local_grid_refinement\")\n",
     "model_name = \"IJm_planeten\"\n",
     "\n",
     "ds = xr.open_dataset(os.path.join(model_ws, f\"{model_name}.nc\"))"

--- a/docs/workflows/11_particle_tracking_prt.ipynb
+++ b/docs/workflows/11_particle_tracking_prt.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_ws = Path(\"../examples/scratch_model\")\n",
+    "model_ws = Path(\"../examples/00_model_from_scratch\")\n",
     "model_name = \"from_scratch\"\n",
     "\n",
     "ds = xr.open_dataset(model_ws / f\"{model_name}.nc\")\n",

--- a/docs/workflows/18_observations.ipynb
+++ b/docs/workflows/18_observations.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_ws = Path(\"../examples/ijmuiden\")\n",
+    "model_ws = Path(\"../examples/03_local_grid_refinement\")\n",
     "model_name = \"IJm_planeten\"\n",
     "\n",
     "# read model dataset\n",

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -546,9 +546,7 @@ def kveq_combined_layers(kv, thickness, reindexer):
     for k, v in reindexer.items():
         if isinstance(v, tuple):
             numerator = np.nansum(thickness.data[v, ...], axis=0)
-            denominator = np.nansum(
-                thickness.data[v, ...] / kv.data[v, ...], axis=0
-            )
+            denominator = np.nansum(thickness.data[v, ...] / kv.data[v, ...], axis=0)
             kveq = np.divide(
                 numerator,
                 denominator,

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -545,10 +545,16 @@ def kveq_combined_layers(kv, thickness, reindexer):
     da_kv = _get_empty_layered_da(kv, nlay=list(reindexer.keys())[-1] + 1)
     for k, v in reindexer.items():
         if isinstance(v, tuple):
-            kveq = np.nansum(thickness.data[v, ...], axis=0) / np.nansum(
+            numerator = np.nansum(thickness.data[v, ...], axis=0)
+            denominator = np.nansum(
                 thickness.data[v, ...] / kv.data[v, ...], axis=0
             )
-            kveq[np.isinf(kveq)] = np.nan
+            kveq = np.divide(
+                numerator,
+                denominator,
+                out=np.full_like(numerator, np.nan),
+                where=denominator != 0,
+            )
         else:
             kveq = kv.data[v]
         da_kv.data[k] = kveq

--- a/nlmod/dims/time.py
+++ b/nlmod/dims/time.py
@@ -266,7 +266,11 @@ def set_ds_time(
             else:
                 time = start + pd.to_timedelta(time, time_units)
         elif isinstance(time[0], str):
-            time = pd.to_datetime(time)
+            try:
+                time = pd.to_datetime(time, format="mixed")
+            except TypeError:
+                # Fallback for older pandas versions without format="mixed".
+                time = pd.to_datetime(time)
             if isinstance(start, cftime.datetime):
                 time = _pd_timestamp_to_cftime(time)
         elif isinstance(time[0], (pd.Timestamp)):

--- a/nlmod/plot/flopy.py
+++ b/nlmod/plot/flopy.py
@@ -23,9 +23,7 @@ def _get_figure(ax=None, gwf=None, figsize=None):
             figsize = (figsize[0], np.round(figsize[1] / 0.02, 0) * 0.02)
 
         base = 10 ** int(np.log10(gwf.modelgrid.extent[1] - gwf.modelgrid.extent[0]))
-        f, ax = get_map(
-            gwf.modelgrid.extent, base=base, figsize=figsize, tight_layout=False
-        )
+        f, ax = get_map(gwf.modelgrid.extent, base=base, figsize=figsize)
         ax.set_aspect("equal", adjustable="box")
     return f, ax
 
@@ -148,8 +146,6 @@ def map_array(
     # axes properties
     axprops = {"xlabel": xlabel, "ylabel": ylabel, "title": title}
     ax.set(**axprops)
-
-    f.tight_layout()
 
     # colorbar
     divider = make_axes_locatable(ax)
@@ -278,8 +274,6 @@ def contour_array(
     # axes properties
     axprops = {"xlabel": xlabel, "ylabel": ylabel, "title": title}
     ax.set(**axprops)
-
-    f.tight_layout()
 
     if animate:
         return f, ax, cs

--- a/nlmod/plot/plot.py
+++ b/nlmod/plot/plot.py
@@ -450,9 +450,7 @@ def _get_figure(ax=None, da=None, ds=None, figsize=None, rotated=False, extent=N
             fmt = "{:.1f}"
         else:
             fmt = "{:.0f}"
-        f, ax = get_map(
-            extent, base=base, figsize=figsize, tight_layout=False, layout=None, fmt=fmt
-        )
+        f, ax = get_map(extent, base=base, figsize=figsize, layout=None, fmt=fmt)
         ax.set_aspect("equal", adjustable="box")
     return f, ax
 
@@ -527,7 +525,6 @@ def map_array(
     else:
         t = None
 
-    fig_tight_layout = ax is None
     f, ax = _get_figure(
         ax=ax, da=da, ds=ds, figsize=figsize, rotated=rotated, extent=extent
     )
@@ -580,8 +577,6 @@ def map_array(
         if levels is not None:
             cbar.set_ticks(levels)
         cbar.set_label(colorbar_label)
-
-    _ = f.tight_layout() if fig_tight_layout else None
 
     if animate:
         return f, ax, pc

--- a/nlmod/read/brp.py
+++ b/nlmod/read/brp.py
@@ -30,8 +30,5 @@ def download_percelen_gdf(extent, year=None):
         gdf = webservices.wfs(url, layer, extent)
         gdf = gdf.set_index("fuuid")
     else:
-        if year < 2009 or year > 2021:
-            raise (ValueError("Only data available from 2009 up to and including 2021"))
-        url = f"https://services.arcgis.com/nSZVuSZjHpEZZbRo/ArcGIS/rest/services/BRP_{year}/FeatureServer"
-        gdf = webservices.arcrest(url, 0, extent=extent)
+        raise ValueError("The argument `year` is not supported any more.")
     return gdf

--- a/nlmod/read/geotop.py
+++ b/nlmod/read/geotop.py
@@ -150,8 +150,11 @@ def to_model_layers(
     geulen = []
     for layer, unit in enumerate(units):
         mask = strat == unit
-        top[layer] = np.nanmax(np.where(mask, z, np.nan), 0) + 0.25
-        bot[layer] = np.nanmin(np.where(mask, z, np.nan), 0) - 0.25
+        # Use finite sentinels to avoid all-NaN slice warnings for empty cells.
+        maxz = np.max(np.where(mask, z, -np.inf), axis=0)
+        minz = np.min(np.where(mask, z, np.inf), axis=0)
+        top[layer] = np.where(np.isfinite(maxz), maxz + 0.25, np.nan)
+        bot[layer] = np.where(np.isfinite(minz), minz - 0.25, np.nan)
         if int(unit) in strat_props.index:
             layers.append(strat_props.at[unit, "code"])
         else:
@@ -530,13 +533,33 @@ def add_kh_and_kv(
                 kv_ar = kv_ar + (probability / kvi)
             probability_total += probability
         if kh_method == "arithmetic_mean":
-            kh_ar = kh_ar / probability_total
+            kh_ar = np.divide(
+                kh_ar,
+                probability_total,
+                out=np.full_like(kh_ar, np.nan),
+                where=probability_total > 0,
+            )
         else:
-            kh_ar = probability_total / kh_ar
+            kh_ar = np.divide(
+                probability_total,
+                kh_ar,
+                out=np.full_like(kh_ar, np.nan),
+                where=kh_ar != 0,
+            )
         if kv_method == "arithmetic_mean":
-            kv_ar = kv_ar / probability_total
+            kv_ar = np.divide(
+                kv_ar,
+                probability_total,
+                out=np.full_like(kv_ar, np.nan),
+                where=probability_total > 0,
+            )
         else:
-            kv_ar = probability_total / kv_ar
+            kv_ar = np.divide(
+                probability_total,
+                kv_ar,
+                out=np.full_like(kv_ar, np.nan),
+                where=kv_ar != 0,
+            )
     else:
         raise (ValueError(f"Unsupported value for stochastic: '{stochastic}'"))
 

--- a/nlmod/read/knmi_data_platform.py
+++ b/nlmod/read/knmi_data_platform.py
@@ -101,7 +101,7 @@ def download_file(
     dataset_name: str,
     dataset_version: str,
     fname: str,
-    dirname: str = ".",
+    dirname: Union[str, os.PathLike] = ".",
     api_key: Optional[str] = None,
     timeout: int = 120,
 ) -> None:
@@ -114,6 +114,7 @@ def download_file(
     )
     r = requests.get(url, headers={"Authorization": api_key}, timeout=timeout)
     rjson = r.json()
+    dirname = os.fspath(dirname)
     if not os.path.isdir(dirname):
         os.makedirs(dirname)
     logger.info(f"Download {fname} to {dirname}")
@@ -133,7 +134,7 @@ def download_files(
     dataset_name: str,
     dataset_version: str,
     fnames: List[str],
-    dirname: str = ".",
+    dirname: Union[str, os.PathLike] = ".",
     api_key: Optional[str] = None,
     timeout: int = 120,
 ) -> None:
@@ -260,9 +261,10 @@ def read_grib(
 
 
 def read_dataset_from_zip(
-    fname: str, hour: Optional[int] = None, **kwargs: dict
+    fname: Union[str, os.PathLike], hour: Optional[int] = None, **kwargs: dict
 ) -> xr.Dataset:
     """Read KNMI data platfrom .zip file to xarray Dataset."""
+    fname = os.fspath(fname)
     if fname.endswith(".zip"):
         with ZipFile(fname) as zipfo:
             fnames = sorted([x for x in zipfo.namelist() if not x.endswith("/")])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,5 +133,3 @@ pydocstyle.convention = "numpy"
 addopts = "--strict-markers --durations=0 --cov-report xml:coverage.xml --cov nlmod -v"
 markers = ["notebooks: run notebooks", "slow: slow tests", "skip: skip tests"]
 
-[tool.coverage.run]
-dynamic_context = "test_function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ full = [
 knmi = ["h5netcdf", "h5py", "nlmod[grib]"]
 grib = ["cfgrib", "ecmwflibs"]
 test = ["pytest>=7", "pytest-cov", "lxml"]
-nbtest = ["nbformat", "nbconvert>6.4.5"]
+nbtest = ["nbformat", "nbconvert>6.4.5", "openpyxl"]
 lint = ["ruff"]
 ci = ["nlmod[full,lint,test,nbtest]"]
 rtd = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def session_model_data_dir(tmp_path_factory):
+    """Use one temp folder for model-data generated and shared during a test session."""
+    source_dir = Path(__file__).parent / "data"
+    model_data_dir = tmp_path_factory.mktemp("model_data")
+
+    # Seed the shared temp directory with checked-in netcdf fixtures.
+    for src in source_dir.glob("*.nc"):
+        shutil.copy2(src, model_data_dir / src.name)
+
+    old_value = os.environ.get(MODEL_DATA_ENV_VAR)
+    os.environ[MODEL_DATA_ENV_VAR] = str(model_data_dir)
+    try:
+        yield model_data_dir
+    finally:
+        if old_value is None:
+            os.environ.pop(MODEL_DATA_ENV_VAR, None)
+        else:
+            os.environ[MODEL_DATA_ENV_VAR] = old_value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,10 @@ def session_model_data_dir(tmp_path_factory):
     source_dir = Path(__file__).parent / "data"
     model_data_dir = tmp_path_factory.mktemp("model_data")
 
-    # Seed the shared temp directory with checked-in netcdf fixtures.
-    for src in source_dir.glob("*.nc"):
-        shutil.copy2(src, model_data_dir / src.name)
+    # Seed the shared temp directory with checked-in fixture files.
+    for pattern in ("*.nc", "*.zip", "*.tar"):
+        for src in source_dir.glob(pattern):
+            shutil.copy2(src, model_data_dir / src.name)
 
     old_value = os.environ.get(MODEL_DATA_ENV_VAR)
     os.environ[MODEL_DATA_ENV_VAR] = str(model_data_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import shutil
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import pytest
 
 MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
@@ -27,3 +28,10 @@ def session_model_data_dir(tmp_path_factory):
             os.environ.pop(MODEL_DATA_ENV_VAR, None)
         else:
             os.environ[MODEL_DATA_ENV_VAR] = old_value
+
+
+@pytest.fixture(autouse=True)
+def close_all_matplotlib_figures():
+    """Close figures created during a test to avoid cross-test leakage."""
+    yield
+    plt.close("all")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,15 @@
 import os
 import shutil
+import gc
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pytest
+
+try:
+    from xarray.backends.file_manager import FILE_CACHE
+except Exception:  # pragma: no cover - defensive for xarray internals
+    FILE_CACHE = None
 
 MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
 
@@ -32,6 +38,9 @@ def session_model_data_dir(tmp_path_factory):
 
 @pytest.fixture(autouse=True)
 def close_all_matplotlib_figures():
-    """Close figures created during a test to avoid cross-test leakage."""
+    """Close figures and backend file handles created during a test."""
     yield
     plt.close("all")
+    gc.collect()
+    if FILE_CACHE is not None:
+        FILE_CACHE.clear()

--- a/tests/test_001_model.py
+++ b/tests/test_001_model.py
@@ -9,11 +9,15 @@ import xarray as xr
 import nlmod
 import util
 
-tmpdir = tempfile.gettempdir()
+tmp_path = tempfile.gettempdir()
 MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
 
 
 def _get_model_data_path(name):
+    return os.path.join(util.get_model_data_dir(), name)
+
+
+def _get_model_ws(name):
     return os.path.join(util.get_model_data_dir(), name)
 
 
@@ -23,27 +27,12 @@ def _ensure_cached_model(name):
         return model_data_path
 
     if name == "small_model":
-        test_create_small_model_grid_only(tmpdir)
-    elif name == "basic_sea_model":
-        test_create_sea_model_grid_only(tmpdir)
-    elif name == "sea_model_grid_50":
-        test_create_sea_model_grid_only_delr_delc_50(tmpdir)
-    elif name == "full_sea_model":
-        _ensure_cached_model("basic_sea_model")
-        basic_path = _get_model_data_path("basic_sea_model.nc")
-        with xr.open_dataset(basic_path, mask_and_scale=False) as ds:
-            ds = ds.load()
-
-        da_name = "surface_water"
-        gdf_surface_water = nlmod.read.rws.get_gdf_surface_water(ds=ds)
-        ds.update(
-            nlmod.read.rws.discretize_surface_water(
-                ds, gdf=gdf_surface_water, da_basename=da_name
-            )
-        )
-        ds.update(nlmod.read.ahn.get_ahn(ds))
-        ds.update(nlmod.read.knmi.get_recharge(ds))
-        ds.to_netcdf(model_data_path)
+        _build_small_model_grid_only(model_name="small_model")
+    elif name == "sea_model_grid_only":
+        _build_sea_model_grid_only(model_name="sea_model")
+    elif name == "sea_model":
+        _ensure_cached_model("sea_model_grid_only")
+        _build_sea_model()
     else:
         raise FileNotFoundError(
             f"No cached model generator is configured for '{name}'."
@@ -57,8 +46,8 @@ def _ensure_cached_model(name):
     return model_data_path
 
 
-def test_model_directories(tmpdir):
-    model_ws = os.path.join(tmpdir, "test_model")
+def test_model_directories(tmp_path):
+    model_ws = os.path.join(tmp_path, "test_model")
     figdir, cachedir = nlmod.util.get_model_dirs(model_ws)
 
 
@@ -72,25 +61,8 @@ def test_snap_extent():
     assert new_extent == [1000.0, 2000.0, 7975.0, 10010.0]
 
 
-def get_ds_time_steady(tmpdir, modelname="test"):
-    model_ws = os.path.join(tmpdir, "test_model")
-    ds = nlmod.base.set_ds_attrs(xr.Dataset(), modelname, model_ws)
-    ds = nlmod.time.set_ds_time(ds, time=["2015-1-2"], start="2015-1-1", steady=True)
-    return ds
-
-
-def get_ds_time_transient(tmpdir, modelname="test"):
-    model_ws = os.path.join(tmpdir, "test_model")
-    ds = nlmod.base.set_ds_attrs(xr.Dataset(), modelname, model_ws)
-    nper = 11
-    time = pd.date_range(start="2015-1-2", periods=nper, freq="D")
-    steady = np.zeros(nper)
-    ds = nlmod.time.set_ds_time(ds, time=time, start="2015-1-1", steady=steady)
-    return ds
-
-
 def test_get_ds():
-    model_ws = os.path.join(tmpdir, "test_model_ds")
+    model_ws = os.path.join(tmp_path, "test_model_ds")
     nlmod.get_ds(
         [-500, 500, -500, 500],
         delr=10.0,
@@ -105,7 +77,7 @@ def test_get_ds():
 
 
 def test_get_ds_variable_delrc():
-    model_ws = os.path.join(tmpdir, "test_model_ds")
+    model_ws = os.path.join(tmp_path, "test_model_ds")
     nlmod.get_ds(
         extent=[-500, 500, -500, 500],
         delr=[100] * 5 + [20] * 5 + [100] * 4,
@@ -120,14 +92,13 @@ def test_get_ds_variable_delrc():
     )
 
 
-@pytest.mark.slow
-def test_create_small_model_grid_only(tmpdir, model_name="test"):
+def _build_small_model_grid_only(model_name="small_model"):
     extent = [98700.0, 99000.0, 489500.0, 489700.0]
     # extent, nrow, ncol = nlmod.read.regis.fit_extent_to_regis(extent, 100, 100)
     regis_geotop_ds = nlmod.read.regis.get_combined_layer_models(
         extent, regis_botm_layer="KRz5", use_regis=True, use_geotop=True
     )
-    model_ws = os.path.join(tmpdir, model_name)
+    model_ws = _get_model_ws(model_name)
     ds = nlmod.base.to_model_ds(
         regis_geotop_ds, model_name, model_ws, delr=100.0, delc=100.0
     )
@@ -163,13 +134,17 @@ def test_create_small_model_grid_only(tmpdir, model_name="test"):
 
 
 @pytest.mark.slow
-def test_create_sea_model_grid_only(tmpdir, model_name="test"):
+def test_create_small_model_grid_only():
+    _build_small_model_grid_only(model_name="small_model")
+
+
+def _build_sea_model_grid_only(model_name="sea_model"):
     extent = [95000.0, 105000.0, 494000.0, 500000.0]
     # extent, nrow, ncol = nlmod.read.regis.fit_extent_to_regis(extent, 100, 100)
     regis_geotop_ds = nlmod.read.regis.get_combined_layer_models(
         extent, use_regis=True, use_geotop=True
     )
-    model_ws = os.path.join(tmpdir, model_name)
+    model_ws = _get_model_ws("sea_model_grid_only")
     ds = nlmod.base.to_model_ds(
         regis_geotop_ds, model_name, model_ws, delr=100.0, delc=100.0
     )
@@ -184,31 +159,24 @@ def test_create_sea_model_grid_only(tmpdir, model_name="test"):
         steady=steady,
     )
 
+    ds.attrs["model_name"] = model_name
+    ds.attrs["model_ws"] = model_ws
+
     # save ds
-    ds.to_netcdf(_get_model_data_path("basic_sea_model.nc"))
+    ds.to_netcdf(_get_model_data_path("sea_model_grid_only.nc"))
 
 
 @pytest.mark.slow
-def test_create_sea_model_grid_only_delr_delc_50(tmpdir, model_name="test"):
-    ds = get_ds_time_transient(tmpdir)
-    extent = [95000.0, 105000.0, 494000.0, 500000.0]
-    # extent, nrow, ncol = nlmod.read.regis.fit_extent_to_regis(extent, 50.0, 50.0)
-    regis_geotop_ds = nlmod.read.regis.get_combined_layer_models(
-        extent, use_regis=True, use_geotop=True
-    )
-    model_ws = os.path.join(tmpdir, model_name)
-    ds = nlmod.base.to_model_ds(
-        regis_geotop_ds, model_name, model_ws, delr=50.0, delc=50.0
-    )
-
-    # save ds
-    ds.to_netcdf(_get_model_data_path("sea_model_grid_50.nc"))
+def test_create_sea_model_grid_only():
+    _build_sea_model_grid_only(model_name="sea_model")
 
 
-@pytest.mark.slow
-def test_create_sea_model(tmpdir):
+def _build_sea_model():
     ds = xr.open_dataset(
-        _get_model_data_path("basic_sea_model.nc"), mask_and_scale=False
+        _get_model_data_path("sea_model_grid_only.nc"), mask_and_scale=False
+    )
+    ds = nlmod.base.set_ds_attrs(
+        ds, model_name="sea_model", model_ws=_get_model_ws("sea_model")
     )
     # create simulation
     sim = nlmod.sim.sim(ds)
@@ -257,157 +225,14 @@ def test_create_sea_model(tmpdir):
     # create recharge package
     _ = nlmod.gwf.rch(ds, gwf)
 
+    ds.to_netcdf(_get_model_data_path("sea_model.nc"))
+
     _ = nlmod.sim.write_and_run(sim, ds)
 
 
 @pytest.mark.slow
-def test_create_sea_model_perlen_list(tmpdir):
-    ds = xr.open_dataset(_get_model_data_path("basic_sea_model.nc"))
-
-    # update model_ws
-    model_ws = os.path.join(tmpdir, "test_model_perlen_list")
-    ds = nlmod.base.set_ds_attrs(ds, ds.model_name, model_ws)
-
-    # create transient with perlen list
-    start = ds.time.start
-    perlen = [3650, 14, 10, 11]  # length of the time steps
-    steady = np.zeros(len(perlen), dtype=int)
-    steady[0] = 1
-
-    # drop time dimension before setting time
-    ds = ds.drop_dims("time")
-
-    # update current ds with new time dicretisation
-    ds = nlmod.time.set_ds_time(
-        ds,
-        time=np.cumsum(perlen),
-        start=start,
-        steady=steady,
-    )
-
-    # create simulation
-    sim = nlmod.sim.sim(ds)
-
-    # create time discretisation
-    _ = nlmod.sim.tdis(ds, sim)
-
-    # create groundwater flow model
-    gwf = nlmod.gwf.gwf(ds, sim)
-
-    # create ims
-    _ = nlmod.sim.ims(sim)
-
-    # Create discretization
-    nlmod.gwf.dis(ds, gwf)
-
-    # create node property flow
-    nlmod.gwf.npf(ds, gwf)
-
-    # Create the initial conditions package
-    nlmod.gwf.ic(ds, gwf, starting_head=1.0)
-
-    # Create the output control package
-    nlmod.gwf.oc(ds, gwf)
-
-    # voeg grote oppervlaktewaterlichamen toe
-    da_name = "surface_water"
-    gdf_surface_water = nlmod.read.rws.get_gdf_surface_water(ds=ds)
-    ds.update(
-        nlmod.read.rws.get_surface_water(ds, gdf=gdf_surface_water, da_basename=da_name)
-    )
-    _ = nlmod.gwf.ghb(ds, gwf, bhead=f"{da_name}_stage", cond=f"{da_name}_cond")
-
-    # surface level drain
-    ds.update(nlmod.read.ahn.get_ahn(ds))
-    nlmod.gwf.surface_drain_from_ds(ds, gwf, 1.0)
-
-    # add constant head cells at model boundaries
-    ds.update(nlmod.grid.mask_model_edge(ds))
-    nlmod.gwf.chd(ds, gwf, mask="edge_mask", head="starting_head")
-
-    # add knmi recharge to the model datasets
-    ds.update(nlmod.read.knmi.get_recharge(ds))
-    # create recharge package
-    nlmod.gwf.rch(ds, gwf)
-
-    nlmod.sim.write_and_run(sim, ds)
-
-
-@pytest.mark.slow
-def test_create_sea_model_perlen_14(tmpdir):
-    ds = xr.open_dataset(_get_model_data_path("basic_sea_model.nc"))
-
-    # update model_ws
-    model_ws = os.path.join(tmpdir, "test_model_perlen_14")
-    ds = nlmod.base.set_ds_attrs(ds, ds.model_name, model_ws)
-
-    # create transient with perlen list
-    perlen = 14  # length of the transient time steps
-    nper = 4
-    start = ds.time.start
-    perlen = perlen * np.ones(nper)
-    perlen[0] = 3652.0  # length of the steady state step
-    steady = np.zeros(nper, dtype=int)
-    steady[0] = 1
-    time = nlmod.time.ds_time_idx_from_tdis_settings(start, perlen=perlen)
-
-    # drop time dimension before setting time
-    ds = ds.drop_dims("time")
-
-    # update current ds with new time discretization
-    ds = nlmod.time.set_ds_time(
-        ds,
-        time=time,
-        start=start,
-        steady=steady,
-    )
-
-    # create simulation
-    sim = nlmod.sim.sim(ds)
-
-    # create time discretisation
-    _ = nlmod.sim.tdis(ds, sim)
-
-    # create ims
-    _ = nlmod.sim.ims(sim)
-
-    # create groundwater flow model
-    gwf = nlmod.gwf.gwf(ds, sim)
-
-    # Create discretization
-    nlmod.gwf.dis(ds, gwf)
-
-    # create node property flow
-    nlmod.gwf.npf(ds, gwf)
-
-    # Create the initial conditions package
-    nlmod.gwf.ic(ds, gwf, starting_head=1.0)
-
-    # Create the output control package
-    nlmod.gwf.oc(ds, gwf)
-
-    # voeg grote oppervlaktewaterlichamen toe
-    da_name = "surface_water"
-    gdf_surface_water = nlmod.read.rws.get_gdf_surface_water(ds=ds)
-    ds.update(
-        nlmod.read.rws.get_surface_water(ds, gdf=gdf_surface_water, da_basename=da_name)
-    )
-    _ = nlmod.gwf.ghb(ds, gwf, bhead=f"{da_name}_stage", cond=f"{da_name}_cond")
-
-    # surface level drain
-    ds.update(nlmod.read.ahn.get_ahn(ds))
-    nlmod.gwf.surface_drain_from_ds(ds, gwf, 1.0)
-
-    # add constant head cells at model boundaries
-    ds.update(nlmod.grid.mask_model_edge(ds))
-    nlmod.gwf.chd(ds, gwf, mask="edge_mask", head="starting_head")
-
-    # add knmi recharge to the model datasets
-    ds.update(nlmod.read.knmi.get_recharge(ds))
-    # create recharge package
-    nlmod.gwf.rch(ds, gwf)
-
-    nlmod.sim.write_and_run(sim, ds)
+def test_create_sea_model():
+    _build_sea_model()
 
 
 # obtaining the test models
@@ -416,14 +241,3 @@ def get_ds_from_cache(name="small_model"):
     # Load into memory so the source file handle can be closed immediately.
     with xr.open_dataset(model_data_path) as ds:
         return ds.load()
-
-
-# other functions
-def _check_tmpdir(tmpdir):
-    # pytest uses a LocalPath object for the tmpdir argument when testing
-    # this function convert a LocalPath object to a string
-
-    if isinstance(tmpdir, str):
-        return tmpdir
-    else:
-        return str(tmpdir)

--- a/tests/test_001_model.py
+++ b/tests/test_001_model.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 import numpy as np
 import pandas as pd
@@ -8,9 +7,6 @@ import xarray as xr
 
 import nlmod
 import util
-
-tmp_path = tempfile.gettempdir()
-MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
 
 
 def _get_model_data_path(name):
@@ -61,7 +57,7 @@ def test_snap_extent():
     assert new_extent == [1000.0, 2000.0, 7975.0, 10010.0]
 
 
-def test_get_ds():
+def test_get_ds(tmp_path):
     model_ws = os.path.join(tmp_path, "test_model_ds")
     nlmod.get_ds(
         [-500, 500, -500, 500],
@@ -76,7 +72,7 @@ def test_get_ds():
     )
 
 
-def test_get_ds_variable_delrc():
+def test_get_ds_variable_delrc(tmp_path):
     model_ws = os.path.join(tmp_path, "test_model_ds")
     nlmod.get_ds(
         extent=[-500, 500, -500, 500],

--- a/tests/test_001_model.py
+++ b/tests/test_001_model.py
@@ -7,9 +7,54 @@ import pytest
 import xarray as xr
 
 import nlmod
+import util
 
 tmpdir = tempfile.gettempdir()
-tst_model_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
+MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
+
+
+def _get_model_data_path(name):
+    return os.path.join(util.get_model_data_dir(), name)
+
+
+def _ensure_cached_model(name):
+    model_data_path = _get_model_data_path(name + ".nc")
+    if os.path.exists(model_data_path):
+        return model_data_path
+
+    if name == "small_model":
+        test_create_small_model_grid_only(tmpdir)
+    elif name == "basic_sea_model":
+        test_create_sea_model_grid_only(tmpdir)
+    elif name == "sea_model_grid_50":
+        test_create_sea_model_grid_only_delr_delc_50(tmpdir)
+    elif name == "full_sea_model":
+        _ensure_cached_model("basic_sea_model")
+        basic_path = _get_model_data_path("basic_sea_model.nc")
+        with xr.open_dataset(basic_path, mask_and_scale=False) as ds:
+            ds = ds.load()
+
+        da_name = "surface_water"
+        gdf_surface_water = nlmod.read.rws.get_gdf_surface_water(ds=ds)
+        ds.update(
+            nlmod.read.rws.discretize_surface_water(
+                ds, gdf=gdf_surface_water, da_basename=da_name
+            )
+        )
+        ds.update(nlmod.read.ahn.get_ahn(ds))
+        ds.update(nlmod.read.knmi.get_recharge(ds))
+        ds.to_netcdf(model_data_path)
+    else:
+        raise FileNotFoundError(
+            f"No cached model generator is configured for '{name}'."
+        )
+
+    if not os.path.exists(model_data_path):
+        raise FileNotFoundError(
+            f"Cached model '{name}' was not created at expected path: {model_data_path}"
+        )
+
+    return model_data_path
 
 
 def test_model_directories(tmpdir):
@@ -114,7 +159,7 @@ def test_create_small_model_grid_only(tmpdir, model_name="test"):
     _ = nlmod.gwf.dis(ds, gwf)
 
     # save ds
-    ds.to_netcdf(os.path.join(tst_model_dir, "small_model.nc"))
+    ds.to_netcdf(_get_model_data_path("small_model.nc"))
 
 
 @pytest.mark.slow
@@ -140,7 +185,7 @@ def test_create_sea_model_grid_only(tmpdir, model_name="test"):
     )
 
     # save ds
-    ds.to_netcdf(os.path.join(tst_model_dir, "basic_sea_model.nc"))
+    ds.to_netcdf(_get_model_data_path("basic_sea_model.nc"))
 
 
 @pytest.mark.slow
@@ -157,13 +202,13 @@ def test_create_sea_model_grid_only_delr_delc_50(tmpdir, model_name="test"):
     )
 
     # save ds
-    ds.to_netcdf(os.path.join(tst_model_dir, "sea_model_grid_50.nc"))
+    ds.to_netcdf(_get_model_data_path("sea_model_grid_50.nc"))
 
 
 @pytest.mark.slow
 def test_create_sea_model(tmpdir):
     ds = xr.open_dataset(
-        os.path.join(tst_model_dir, "basic_sea_model.nc"), mask_and_scale=False
+        _get_model_data_path("basic_sea_model.nc"), mask_and_scale=False
     )
     # create simulation
     sim = nlmod.sim.sim(ds)
@@ -217,7 +262,7 @@ def test_create_sea_model(tmpdir):
 
 @pytest.mark.slow
 def test_create_sea_model_perlen_list(tmpdir):
-    ds = xr.open_dataset(os.path.join(tst_model_dir, "basic_sea_model.nc"))
+    ds = xr.open_dataset(_get_model_data_path("basic_sea_model.nc"))
 
     # update model_ws
     model_ws = os.path.join(tmpdir, "test_model_perlen_list")
@@ -290,7 +335,7 @@ def test_create_sea_model_perlen_list(tmpdir):
 
 @pytest.mark.slow
 def test_create_sea_model_perlen_14(tmpdir):
-    ds = xr.open_dataset(os.path.join(tst_model_dir, "basic_sea_model.nc"))
+    ds = xr.open_dataset(_get_model_data_path("basic_sea_model.nc"))
 
     # update model_ws
     model_ws = os.path.join(tmpdir, "test_model_perlen_14")
@@ -367,8 +412,10 @@ def test_create_sea_model_perlen_14(tmpdir):
 
 # obtaining the test models
 def get_ds_from_cache(name="small_model"):
-    ds = xr.open_dataset(os.path.join(tst_model_dir, name + ".nc"))
-    return ds
+    model_data_path = _ensure_cached_model(name)
+    # Load into memory so the source file handle can be closed immediately.
+    with xr.open_dataset(model_data_path) as ds:
+        return ds.load()
 
 
 # other functions

--- a/tests/test_003_mfpackages.py
+++ b/tests/test_003_mfpackages.py
@@ -23,7 +23,7 @@ def sim_tdis_gwf_ims_from_ds(tmpdir):
     return sim, gwf
 
 
-def dis_from_ds(tmpdir):
+def test_dis_from_ds(tmpdir):
     ds = test_001_model.get_ds_from_cache("small_model")
 
     _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
@@ -31,26 +31,26 @@ def dis_from_ds(tmpdir):
     nlmod.gwf.dis(ds, gwf)
 
 
-def npf_from_ds(tmpdir):
+def test_npf_from_ds(tmpdir):
     ds = test_001_model.get_ds_from_cache("small_model")
     _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
-    nlmod.gwf.dis(ds)
+    nlmod.gwf.dis(ds, gwf)
     nlmod.gwf.npf(ds, gwf)
 
 
-def oc_from_ds(tmpdir):
+def test_oc_from_ds(tmpdir):
     ds = test_001_model.get_ds_from_cache("small_model")
     _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
     nlmod.gwf.oc(ds, gwf)
 
 
-def sto_from_ds(tmpdir):
+def test_sto_from_ds(tmpdir):
     ds = test_001_model.get_ds_from_cache("small_model")
     _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
     nlmod.gwf.sto(ds, gwf)
 
 
-def ghb_from_ds(tmpdir):
+def test_ghb_from_ds(tmpdir):
     ds = test_001_model.get_ds_from_cache("full_sea_model")
     _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
     _ = nlmod.gwf.dis(ds, gwf)
@@ -58,7 +58,7 @@ def ghb_from_ds(tmpdir):
     nlmod.gwf.ghb(ds, gwf, bhead="surface_water_stage", cond="surface_water_cond")
 
 
-def rch_from_ds(tmpdir):
+def test_rch_from_ds(tmpdir):
     ds = test_001_model.get_ds_from_cache("full_sea_model")
     _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
     _ = nlmod.gwf.dis(ds, gwf)
@@ -66,14 +66,14 @@ def rch_from_ds(tmpdir):
     nlmod.gwf.rch(ds, gwf)
 
 
-def drn_from_ds(tmpdir):
+def test_drn_from_ds(tmpdir):
     ds = test_001_model.get_ds_from_cache("full_sea_model")
     _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
     _ = nlmod.gwf.dis(ds, gwf)
     nlmod.gwf.surface_drain_from_ds(ds, gwf, 1.0)
 
 
-def chd_from_ds(tmpdir):
+def test_chd_from_ds(tmpdir):
     ds = test_001_model.get_ds_from_cache("small_model")
     _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
     _ = nlmod.gwf.dis(ds, gwf)
@@ -85,7 +85,7 @@ def chd_from_ds(tmpdir):
     nlmod.gwf.chd(ds, gwf, mask="edge_mask", head="starting_head")
 
 
-def get_value_from_ds_datavar():
+def test_get_value_from_ds_datavar():
     ds = xr.Dataset(
         coords={
             "layer": [0, 1],
@@ -104,7 +104,7 @@ def get_value_from_ds_datavar():
 
     # get value from ds, variable and stored name are different
     v1 = nlmod.util._get_value_from_ds_datavar(ds, "test", "test_var")
-    xr.testing.assert_equal(ds["test_var"].values, v1)
+    (ds["test_var"].values == v1).all()
 
     # do not get value from ds, value is Data Array, should log info msg
     v2 = nlmod.util._get_value_from_ds_datavar(ds, "test", v0, return_da=True)
@@ -124,7 +124,7 @@ def get_value_from_ds_datavar():
     assert v5 is None, "should be None."
 
 
-def get_value_from_ds_attr():
+def test_get_value_from_ds_attr():
     ds = xr.Dataset(
         coords={
             "layer": [0, 1],
@@ -159,7 +159,7 @@ def get_value_from_ds_attr():
     v5 = nlmod.util._get_value_from_ds_attr(ds, "test", "test", value=3.0)
     assert v5 == 3.0
 
-    # user user-provided str value, no msg, since "test" is not in attrs
+    # use user-provided str value, no msg, since "test" is not in attrs
     v6 = nlmod.util._get_value_from_ds_attr(ds, "test", "test", value="test")
     assert v6 == "test"
 

--- a/tests/test_003_mfpackages.py
+++ b/tests/test_003_mfpackages.py
@@ -5,8 +5,8 @@ import xarray as xr
 import nlmod
 
 
-def sim_tdis_gwf_ims_from_ds(tmpdir):
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+def sim_tdis_gwf_ims_from_ds():
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
 
     # create simulation
     sim = nlmod.sim.sim(ds)
@@ -23,59 +23,59 @@ def sim_tdis_gwf_ims_from_ds(tmpdir):
     return sim, gwf
 
 
-def test_dis_from_ds(tmpdir):
+def test_dis_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
 
-    _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
+    _, gwf = sim_tdis_gwf_ims_from_ds()
 
     nlmod.gwf.dis(ds, gwf)
 
 
-def test_npf_from_ds(tmpdir):
+def test_npf_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
+    _, gwf = sim_tdis_gwf_ims_from_ds()
     nlmod.gwf.dis(ds, gwf)
     nlmod.gwf.npf(ds, gwf)
 
 
-def test_oc_from_ds(tmpdir):
+def test_oc_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
+    _, gwf = sim_tdis_gwf_ims_from_ds()
     nlmod.gwf.oc(ds, gwf)
 
 
-def test_sto_from_ds(tmpdir):
+def test_sto_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
+    _, gwf = sim_tdis_gwf_ims_from_ds()
     nlmod.gwf.sto(ds, gwf)
 
 
-def test_ghb_from_ds(tmpdir):
-    ds = test_001_model.get_ds_from_cache("full_sea_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
+def test_ghb_from_ds():
+    ds = test_001_model.get_ds_from_cache("sea_model")
+    _, gwf = sim_tdis_gwf_ims_from_ds()
     _ = nlmod.gwf.dis(ds, gwf)
 
     nlmod.gwf.ghb(ds, gwf, bhead="surface_water_stage", cond="surface_water_cond")
 
 
-def test_rch_from_ds(tmpdir):
-    ds = test_001_model.get_ds_from_cache("full_sea_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
+def test_rch_from_ds():
+    ds = test_001_model.get_ds_from_cache("sea_model")
+    _, gwf = sim_tdis_gwf_ims_from_ds()
     _ = nlmod.gwf.dis(ds, gwf)
 
     nlmod.gwf.rch(ds, gwf)
 
 
-def test_drn_from_ds(tmpdir):
-    ds = test_001_model.get_ds_from_cache("full_sea_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
+def test_drn_from_ds():
+    ds = test_001_model.get_ds_from_cache("sea_model")
+    _, gwf = sim_tdis_gwf_ims_from_ds()
     _ = nlmod.gwf.dis(ds, gwf)
     nlmod.gwf.surface_drain_from_ds(ds, gwf, 1.0)
 
 
-def test_chd_from_ds(tmpdir):
+def test_chd_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds(tmpdir)
+    _, gwf = sim_tdis_gwf_ims_from_ds()
     _ = nlmod.gwf.dis(ds, gwf)
 
     _ = nlmod.gwf.ic(ds, gwf, starting_head=1.0)

--- a/tests/test_003_mfpackages.py
+++ b/tests/test_003_mfpackages.py
@@ -5,9 +5,7 @@ import xarray as xr
 import nlmod
 
 
-def sim_tdis_gwf_ims_from_ds():
-    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
-
+def sim_tdis_gwf_ims_from_ds(ds):
     # create simulation
     sim = nlmod.sim.sim(ds)
 
@@ -26,33 +24,33 @@ def sim_tdis_gwf_ims_from_ds():
 def test_dis_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
 
-    _, gwf = sim_tdis_gwf_ims_from_ds()
+    _, gwf = sim_tdis_gwf_ims_from_ds(ds)
 
     nlmod.gwf.dis(ds, gwf)
 
 
 def test_npf_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds()
+    _, gwf = sim_tdis_gwf_ims_from_ds(ds)
     nlmod.gwf.dis(ds, gwf)
     nlmod.gwf.npf(ds, gwf)
 
 
 def test_oc_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds()
+    _, gwf = sim_tdis_gwf_ims_from_ds(ds)
     nlmod.gwf.oc(ds, gwf)
 
 
 def test_sto_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds()
+    _, gwf = sim_tdis_gwf_ims_from_ds(ds)
     nlmod.gwf.sto(ds, gwf)
 
 
 def test_ghb_from_ds():
     ds = test_001_model.get_ds_from_cache("sea_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds()
+    _, gwf = sim_tdis_gwf_ims_from_ds(ds)
     _ = nlmod.gwf.dis(ds, gwf)
 
     nlmod.gwf.ghb(ds, gwf, bhead="surface_water_stage", cond="surface_water_cond")
@@ -60,7 +58,7 @@ def test_ghb_from_ds():
 
 def test_rch_from_ds():
     ds = test_001_model.get_ds_from_cache("sea_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds()
+    _, gwf = sim_tdis_gwf_ims_from_ds(ds)
     _ = nlmod.gwf.dis(ds, gwf)
 
     nlmod.gwf.rch(ds, gwf)
@@ -68,14 +66,14 @@ def test_rch_from_ds():
 
 def test_drn_from_ds():
     ds = test_001_model.get_ds_from_cache("sea_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds()
+    _, gwf = sim_tdis_gwf_ims_from_ds(ds)
     _ = nlmod.gwf.dis(ds, gwf)
     nlmod.gwf.surface_drain_from_ds(ds, gwf, 1.0)
 
 
 def test_chd_from_ds():
     ds = test_001_model.get_ds_from_cache("small_model")
-    _, gwf = sim_tdis_gwf_ims_from_ds()
+    _, gwf = sim_tdis_gwf_ims_from_ds(ds)
     _ = nlmod.gwf.dis(ds, gwf)
 
     _ = nlmod.gwf.ic(ds, gwf, starting_head=1.0)

--- a/tests/test_004_northsea.py
+++ b/tests/test_004_northsea.py
@@ -12,13 +12,14 @@ def test_surface_water_to_dataset():
     # model with sea
     ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
     name = "surface_water"
-    nlmod.read.rws.get_surface_water(ds, da_basename=name)
+    gdf_surface_water = nlmod.read.rws.get_gdf_surface_water(ds)
+    nlmod.read.rws.discretize_surface_water(ds, gdf_surface_water, da_basename=name)
 
 
 def test_get_northsea_seamodel():
     # model with sea
     ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
-    ds_sea = nlmod.read.rws.get_northsea(ds)
+    ds_sea = nlmod.read.rws.discretize_northsea(ds)
 
     assert (ds_sea.northsea == 1).sum() > 0
 
@@ -26,7 +27,7 @@ def test_get_northsea_seamodel():
 def test_get_northsea_nosea():
     # model without sea
     ds = test_001_model.get_ds_from_cache("small_model")
-    ds_sea = nlmod.read.rws.get_northsea(ds)
+    ds_sea = nlmod.read.rws.discretize_northsea(ds)
 
     assert (ds_sea.northsea == 1).sum() == 0
 
@@ -34,7 +35,7 @@ def test_get_northsea_nosea():
 def test_fill_top_bot_kh_kv_seamodel():
     # model with sea
     ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
-    ds.update(nlmod.read.rws.get_northsea(ds))
+    ds.update(nlmod.read.rws.discretize_northsea(ds))
 
     fal = nlmod.layers.get_first_active_layer(ds)
     fill_mask = (fal == fal.nodata) * ds["northsea"]
@@ -44,7 +45,7 @@ def test_fill_top_bot_kh_kv_seamodel():
 def test_fill_top_bot_kh_kv_nosea():
     # model with sea
     ds = test_001_model.get_ds_from_cache("small_model")
-    ds.update(nlmod.read.rws.get_northsea(ds))
+    ds.update(nlmod.read.rws.discretize_northsea(ds))
 
     fal = nlmod.layers.get_first_active_layer(ds)
     fill_mask = (fal == fal.nodata) * ds["northsea"]
@@ -54,7 +55,7 @@ def test_fill_top_bot_kh_kv_nosea():
 def test_get_bathymetry_seamodel():
     # model with sea
     ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
-    ds.update(nlmod.read.rws.get_northsea(ds))
+    ds.update(nlmod.read.rws.discretize_northsea(ds))
     ds_bathymetry = nlmod.read.jarkus.get_bathymetry(ds, datavar_sea="northsea")
 
     assert (~ds_bathymetry.bathymetry.isnull()).sum() > 0
@@ -63,7 +64,7 @@ def test_get_bathymetry_seamodel():
 def test_get_bathymetry_nosea():
     # model without sea
     ds = test_001_model.get_ds_from_cache("small_model")
-    ds.update(nlmod.read.rws.get_northsea(ds))
+    ds.update(nlmod.read.rws.discretize_northsea(ds))
     ds_bathymetry = nlmod.read.jarkus.get_bathymetry(ds, datavar_sea="northsea")
 
     assert (~ds_bathymetry.bathymetry.isnull()).sum() == 0

--- a/tests/test_004_northsea.py
+++ b/tests/test_004_northsea.py
@@ -10,14 +10,14 @@ def test_get_gdf_opp_water():
 
 def test_surface_water_to_dataset():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
     name = "surface_water"
     nlmod.read.rws.get_surface_water(ds, da_basename=name)
 
 
 def test_get_northsea_seamodel():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
     ds_sea = nlmod.read.rws.get_northsea(ds)
 
     assert (ds_sea.northsea == 1).sum() > 0
@@ -33,7 +33,7 @@ def test_get_northsea_nosea():
 
 def test_fill_top_bot_kh_kv_seamodel():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
     ds.update(nlmod.read.rws.get_northsea(ds))
 
     fal = nlmod.layers.get_first_active_layer(ds)
@@ -53,7 +53,7 @@ def test_fill_top_bot_kh_kv_nosea():
 
 def test_get_bathymetry_seamodel():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
     ds.update(nlmod.read.rws.get_northsea(ds))
     ds_bathymetry = nlmod.read.jarkus.get_bathymetry(ds, datavar_sea="northsea")
 
@@ -71,7 +71,7 @@ def test_get_bathymetry_nosea():
 
 def test_add_bathymetry_to_top_bot_kh_kv_seamodel():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
     ds.update(nlmod.read.rws.discretize_northsea(ds))
     bathymetry = nlmod.read.jarkus.get_bathymetry(ds, datavar_sea="northsea")
     ds.update(bathymetry.drop_vars("time"))

--- a/tests/test_005_external_data.py
+++ b/tests/test_005_external_data.py
@@ -12,7 +12,7 @@ import nlmod
 
 def test_get_recharge():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
 
     # add knmi recharge to the model dataset
     ds.update(nlmod.read.knmi.get_recharge(ds))
@@ -29,7 +29,7 @@ def test_get_recharge_most_common():
 
 def test_get_recharge_steady_state():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
 
     # modify mtime
     ds = ds.drop_dims("time")
@@ -197,7 +197,7 @@ def test_download_ahn6():
 
 def test_get_ahn():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
 
     # add ahn data to the model dataset
     ahn_ds = nlmod.read.ahn.get_ahn(ds)
@@ -224,7 +224,7 @@ def test_check_ahn_files_up_to_date():
 
 def test_get_surface_water_ghb():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
 
     # create simulation
     sim = nlmod.sim.sim(ds)
@@ -253,7 +253,7 @@ def test_get_brp():
 @pytest.mark.skip(reason="slow")
 def test_get_bofek():
     # model with sea
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model_grid_only")
 
     # add knmi recharge to the model dataset
     gdf_bofek = nlmod.read.bofek.download_bofek_gdf(ds)

--- a/tests/test_005_external_data.py
+++ b/tests/test_005_external_data.py
@@ -241,7 +241,14 @@ def test_get_surface_water_ghb():
     nlmod.gwf.dis(ds, gwf)
 
     # add surface water levels to the model dataset
-    ds.update(nlmod.read.rws.get_surface_water(ds, da_basename="surface_water"))
+    gdf_surface_water = nlmod.read.rws.get_gdf_surface_water(ds)
+    ds.update(
+        nlmod.read.rws.discretize_surface_water(
+            ds,
+            gdf_surface_water,
+            da_basename="surface_water",
+        )
+    )
 
 
 def test_get_brp():

--- a/tests/test_006_caching.py
+++ b/tests/test_006_caching.py
@@ -51,7 +51,7 @@ def test_cache_ahn_data_array():
 
 def test_cache_northsea_data_array():
     """Test caching of AHN data array. Does have dataset as argument."""
-    from nlmod.read.rws import get_northsea
+    from nlmod.read.rws import discretize_northsea
 
     ds1 = nlmod.get_ds(
         [119_700, 120_000, 441_900, 442_000],
@@ -78,12 +78,12 @@ def test_cache_northsea_data_array():
         assert not os.path.exists(os.path.join(tmp_path, cache_name)), (
             "Cache should not exist yet1"
         )
-        out1_no_cache = get_northsea(ds1)
+        out1_no_cache = discretize_northsea(ds1)
         assert not os.path.exists(os.path.join(tmp_path, cache_name)), (
             "Cache should not exist yet2"
         )
 
-        out1_cached = get_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
+        out1_cached = discretize_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
         assert os.path.exists(os.path.join(tmp_path, cache_name)), (
             "Cache should exist by now"
         )
@@ -91,20 +91,20 @@ def test_cache_northsea_data_array():
         modification_time1 = os.path.getmtime(os.path.join(tmp_path, cache_name))
 
         # Check if the cache is used. If not, cache is rewritten and modification time changes
-        out1_cache = get_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
+        out1_cache = discretize_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
         assert out1_cache.equals(out1_no_cache)
         modification_time2 = os.path.getmtime(os.path.join(tmp_path, cache_name))
         assert modification_time1 == modification_time2, "Cache should not be rewritten"
 
         # Only properties of `coords_2d` determine if the cache is used. Cache should still be used.
         ds1["toppertje"] = ds1.top + 1
-        out1_cache = get_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
+        out1_cache = discretize_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
         assert out1_cache.equals(out1_no_cache)
         modification_time2 = os.path.getmtime(os.path.join(tmp_path, cache_name))
         assert modification_time1 == modification_time2, "Cache should not be rewritten"
 
         # Different extent should not lead to using the cache
-        out2_cache = get_northsea(ds2, cachedir=tmp_path, cachename=cache_name)
+        out2_cache = discretize_northsea(ds2, cachedir=tmp_path, cachename=cache_name)
         modification_time3 = os.path.getmtime(os.path.join(tmp_path, cache_name))
         assert modification_time1 != modification_time3, (
             "Cache should have been rewritten"

--- a/tests/test_006_caching.py
+++ b/tests/test_006_caching.py
@@ -9,44 +9,44 @@ def test_cache_ahn_data_array():
     extent = [119_900, 120_000, 441_900, 442_000]
     cache_name = "ahn4.nc"
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        assert not os.path.exists(
-            os.path.join(tmpdir, cache_name)
-        ), "Cache should not exist yet1"
+    with tempfile.TemporaryDirectory() as tmp_path:
+        assert not os.path.exists(os.path.join(tmp_path, cache_name)), (
+            "Cache should not exist yet1"
+        )
         ahn_no_cache = nlmod.read.ahn.download_ahn4(extent)
-        assert not os.path.exists(
-            os.path.join(tmpdir, cache_name)
-        ), "Cache should not exist yet2"
+        assert not os.path.exists(os.path.join(tmp_path, cache_name)), (
+            "Cache should not exist yet2"
+        )
 
         ahn_cached = nlmod.read.ahn.download_ahn4(
-            extent, cachedir=tmpdir, cachename=cache_name
+            extent, cachedir=tmp_path, cachename=cache_name
         )
-        assert os.path.exists(
-            os.path.join(tmpdir, cache_name)
-        ), "Cache should have existed by now"
+        assert os.path.exists(os.path.join(tmp_path, cache_name)), (
+            "Cache should have existed by now"
+        )
         assert ahn_cached.equals(ahn_no_cache)
-        modification_time1 = os.path.getmtime(os.path.join(tmpdir, cache_name))
+        modification_time1 = os.path.getmtime(os.path.join(tmp_path, cache_name))
 
         # Check if the cache is used. If not, cache is rewritten and modification time changes
         ahn_cache = nlmod.read.ahn.download_ahn4(
-            extent, cachedir=tmpdir, cachename=cache_name
+            extent, cachedir=tmp_path, cachename=cache_name
         )
         assert ahn_cache.equals(ahn_no_cache)
-        modification_time2 = os.path.getmtime(os.path.join(tmpdir, cache_name))
+        modification_time2 = os.path.getmtime(os.path.join(tmp_path, cache_name))
         assert modification_time1 == modification_time2, "Cache should not be rewritten"
 
         # Different extent should not lead to using the cache
         extent = [119_800, 120_000, 441_900, 442_000]
         ahn_cache = nlmod.read.ahn.download_ahn4(
-            extent, cachedir=tmpdir, cachename=cache_name
+            extent, cachedir=tmp_path, cachename=cache_name
         )
-        modification_time3 = os.path.getmtime(os.path.join(tmpdir, cache_name))
-        assert (
-            modification_time1 != modification_time3
-        ), "Cache should have been rewritten"
+        modification_time3 = os.path.getmtime(os.path.join(tmp_path, cache_name))
+        assert modification_time1 != modification_time3, (
+            "Cache should have been rewritten"
+        )
 
         # clear cache again
-        nlmod.cache.clear_cache(tmpdir, prompt=False)
+        nlmod.cache.clear_cache(tmp_path, prompt=False)
 
 
 def test_cache_northsea_data_array():
@@ -74,39 +74,39 @@ def test_cache_northsea_data_array():
 
     cache_name = "northsea.nc"
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        assert not os.path.exists(
-            os.path.join(tmpdir, cache_name)
-        ), "Cache should not exist yet1"
+    with tempfile.TemporaryDirectory() as tmp_path:
+        assert not os.path.exists(os.path.join(tmp_path, cache_name)), (
+            "Cache should not exist yet1"
+        )
         out1_no_cache = get_northsea(ds1)
-        assert not os.path.exists(
-            os.path.join(tmpdir, cache_name)
-        ), "Cache should not exist yet2"
+        assert not os.path.exists(os.path.join(tmp_path, cache_name)), (
+            "Cache should not exist yet2"
+        )
 
-        out1_cached = get_northsea(ds1, cachedir=tmpdir, cachename=cache_name)
-        assert os.path.exists(
-            os.path.join(tmpdir, cache_name)
-        ), "Cache should exist by now"
+        out1_cached = get_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
+        assert os.path.exists(os.path.join(tmp_path, cache_name)), (
+            "Cache should exist by now"
+        )
         assert out1_cached.equals(out1_no_cache)
-        modification_time1 = os.path.getmtime(os.path.join(tmpdir, cache_name))
+        modification_time1 = os.path.getmtime(os.path.join(tmp_path, cache_name))
 
         # Check if the cache is used. If not, cache is rewritten and modification time changes
-        out1_cache = get_northsea(ds1, cachedir=tmpdir, cachename=cache_name)
+        out1_cache = get_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
         assert out1_cache.equals(out1_no_cache)
-        modification_time2 = os.path.getmtime(os.path.join(tmpdir, cache_name))
+        modification_time2 = os.path.getmtime(os.path.join(tmp_path, cache_name))
         assert modification_time1 == modification_time2, "Cache should not be rewritten"
 
         # Only properties of `coords_2d` determine if the cache is used. Cache should still be used.
         ds1["toppertje"] = ds1.top + 1
-        out1_cache = get_northsea(ds1, cachedir=tmpdir, cachename=cache_name)
+        out1_cache = get_northsea(ds1, cachedir=tmp_path, cachename=cache_name)
         assert out1_cache.equals(out1_no_cache)
-        modification_time2 = os.path.getmtime(os.path.join(tmpdir, cache_name))
+        modification_time2 = os.path.getmtime(os.path.join(tmp_path, cache_name))
         assert modification_time1 == modification_time2, "Cache should not be rewritten"
 
         # Different extent should not lead to using the cache
-        out2_cache = get_northsea(ds2, cachedir=tmpdir, cachename=cache_name)
-        modification_time3 = os.path.getmtime(os.path.join(tmpdir, cache_name))
-        assert (
-            modification_time1 != modification_time3
-        ), "Cache should have been rewritten"
+        out2_cache = get_northsea(ds2, cachedir=tmp_path, cachename=cache_name)
+        modification_time3 = os.path.getmtime(os.path.join(tmp_path, cache_name))
+        assert modification_time1 != modification_time3, (
+            "Cache should have been rewritten"
+        )
         assert not out2_cache.equals(out1_no_cache)

--- a/tests/test_007_run_notebooks.py
+++ b/tests/test_007_run_notebooks.py
@@ -40,9 +40,13 @@ NOTEBOOK_DEPENDENCIES = {
         "examples/03_local_grid_refinement.ipynb",
     ],
     "utilities/13_plot_methods.ipynb": ["examples/09_schoonhoven.ipynb"],
-    "workflows/03_aggregating_surface_water.ipynb": ["data_sources/02_surface_water.ipynb"],
+    "workflows/03_aggregating_surface_water.ipynb": [
+        "data_sources/02_surface_water.ipynb"
+    ],
     "workflows/10_modpath.ipynb": ["examples/03_local_grid_refinement.ipynb"],
-    "workflows/11_particle_tracking_prt.ipynb": ["examples/00_model_from_scratch.ipynb"],
+    "workflows/11_particle_tracking_prt.ipynb": [
+        "examples/00_model_from_scratch.ipynb"
+    ],
     "workflows/18_observations.ipynb": ["examples/03_local_grid_refinement.ipynb"],
 }
 

--- a/tests/test_007_run_notebooks.py
+++ b/tests/test_007_run_notebooks.py
@@ -35,6 +35,10 @@ NOTEBOOKS_BY_REL = {path.relative_to(docs_dir).as_posix(): path for path in NOTE
 NOTEBOOK_DEPENDENCIES = {
     "examples/09_schoonhoven.ipynb": ["data_sources/02_surface_water.ipynb"],
     "examples/14_stromingen_example.ipynb": ["data_sources/02_surface_water.ipynb"],
+    "utilities/08_gis.ipynb": [
+        "examples/01_basic_model.ipynb",
+        "examples/03_local_grid_refinement.ipynb",
+    ],
     "utilities/13_plot_methods.ipynb": ["examples/09_schoonhoven.ipynb"],
     "workflows/03_aggregating_surface_water.ipynb": ["data_sources/02_surface_water.ipynb"],
     "workflows/10_modpath.ipynb": ["examples/03_local_grid_refinement.ipynb"],

--- a/tests/test_007_run_notebooks.py
+++ b/tests/test_007_run_notebooks.py
@@ -1,111 +1,76 @@
-"""run notebooks in the examples directory."""
+"""Run all notebooks in the docs directory recursively."""
 
 # ruff: noqa: D103
-import os
+import re
+from pathlib import Path
 
 import nbformat
 import pytest
 from nbconvert.preprocessors import ExecutePreprocessor
 
-tst_dir = os.path.dirname(os.path.realpath(__file__))
-nbdir = os.path.join(tst_dir, "..", "docs", "examples")
+tst_dir = Path(__file__).resolve().parent
+docs_dir = (tst_dir / ".." / "docs").resolve()
 
 
-def _run_notebook(nbdir, fname):
-    fname_nb = os.path.join(nbdir, fname)
-    with open(fname_nb) as f:
+def _is_dated_notebook_copy(path):
+    return re.match(r"^\d{8,10}_", path.name) is not None
+
+
+def _iter_notebooks(base_dir):
+    for path in sorted(base_dir.rglob("*.ipynb")):
+        rel_parts = path.relative_to(base_dir).parts
+        if rel_parts and rel_parts[0] == "build":
+            continue
+        if ".ipynb_checkpoints" in rel_parts:
+            continue
+        if _is_dated_notebook_copy(path):
+            continue
+        yield path
+
+
+NOTEBOOKS = list(_iter_notebooks(docs_dir))
+NOTEBOOKS_BY_REL = {path.relative_to(docs_dir).as_posix(): path for path in NOTEBOOKS}
+
+# Some notebooks consume artifacts produced by other notebooks.
+NOTEBOOK_DEPENDENCIES = {
+    "examples/09_schoonhoven.ipynb": ["data_sources/02_surface_water.ipynb"],
+    "examples/14_stromingen_example.ipynb": ["data_sources/02_surface_water.ipynb"],
+    "utilities/13_plot_methods.ipynb": ["examples/09_schoonhoven.ipynb"],
+    "workflows/03_aggregating_surface_water.ipynb": ["data_sources/02_surface_water.ipynb"],
+    "workflows/10_modpath.ipynb": ["examples/03_local_grid_refinement.ipynb"],
+    "workflows/11_particle_tracking_prt.ipynb": ["examples/00_model_from_scratch.ipynb"],
+    "workflows/18_observations.ipynb": ["examples/03_local_grid_refinement.ipynb"],
+}
+
+_EXECUTED_NOTEBOOKS = set()
+
+
+def _run_notebook(path):
+    with path.open(encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
     ep = ExecutePreprocessor(timeout=6000)
-    out = ep.preprocess(nb, {"metadata": {"path": nbdir}})
-
-    return out
+    ep.preprocess(nb, {"metadata": {"path": str(path.parent)}})
 
 
-@pytest.mark.notebooks
-def test_run_notebook_00_model_from_scratch():
-    _run_notebook(nbdir, "00_model_from_scratch.ipynb")
+def _run_with_dependencies(path):
+    rel = path.relative_to(docs_dir).as_posix()
+    for dep_rel in NOTEBOOK_DEPENDENCIES.get(rel, []):
+        dep_path = NOTEBOOKS_BY_REL.get(dep_rel)
+        if dep_path is None:
+            raise RuntimeError(f"Notebook dependency not found: {dep_rel}")
+        if dep_path not in _EXECUTED_NOTEBOOKS:
+            _run_with_dependencies(dep_path)
 
-
-@pytest.mark.notebooks
-def test_run_notebook_01_basic_model():
-    _run_notebook(nbdir, "01_basic_model.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_02_surface_water():
-    _run_notebook(nbdir, "02_surface_water.ipynb")
+    if path not in _EXECUTED_NOTEBOOKS:
+        _run_notebook(path)
+        _EXECUTED_NOTEBOOKS.add(path)
 
 
 @pytest.mark.notebooks
-def test_run_notebook_03_local_grid_refinement():
-    _run_notebook(nbdir, "03_local_grid_refinement.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_04_modifying_layermodels():
-    _run_notebook(nbdir, "04_modifying_layermodels.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_05_caching():
-    _run_notebook(nbdir, "05_caching.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_06_gridding_vector_data():
-    _run_notebook(nbdir, "06_gridding_vector_data.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_07_resampling():
-    _run_notebook(nbdir, "07_resampling.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_08_gis():
-    _run_notebook(nbdir, "08_gis.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_09_schoonhoven():
-    _run_notebook(nbdir, "09_schoonhoven.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_10_modpath():
-    _run_notebook(nbdir, "10_modpath.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_11_grid_rotation():
-    _run_notebook(nbdir, "11_grid_rotation.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_12_layer_generation():
-    _run_notebook(nbdir, "12_layer_generation.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_13_plot_methods():
-    _run_notebook(nbdir, "13_plot_methods.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_14_stromingen_example():
-    _run_notebook(nbdir, "14_stromingen_example.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_15_geotop():
-    _run_notebook(nbdir, "15_geotop.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_16_groundwater_transport():
-    _run_notebook(nbdir, "16_groundwater_transport.ipynb")
-
-
-@pytest.mark.notebooks
-def test_run_notebook_17_unsaturated_zone_flow():
-    _run_notebook(nbdir, "17_unsaturated_zone_flow.ipynb")
+@pytest.mark.parametrize(
+    "notebook_path",
+    NOTEBOOKS,
+    ids=[str(path.relative_to(docs_dir)) for path in NOTEBOOKS],
+)
+def test_run_notebook(notebook_path):
+    _run_with_dependencies(notebook_path)

--- a/tests/test_008_waterboard.py
+++ b/tests/test_008_waterboard.py
@@ -1,11 +1,11 @@
 import os
-import tempfile
 
 import matplotlib
 import numpy as np
 import pytest
 
 import nlmod
+import util
 
 # def test_download_polygons(): # is tested in test_024_administrative.test_get_waterboards
 #     nlmod.read.waterboard.get_polygons()
@@ -47,7 +47,7 @@ def get_ahn_colormap(name="ahn", N=256):
 def test_download_level_areas(
     data_kind="level_areas", plot=True, save=True, figdir=r"..\docs\_static"
 ):
-    cachedir = os.path.join(tempfile.tempdir, "test_download_level_areas")
+    cachedir = os.path.join(util.get_model_data_dir(), "test_download_level_areas")
     if not os.path.isdir(cachedir):
         os.makedirs(cachedir)
 
@@ -123,7 +123,7 @@ def test_download_watercourses(plot=True):
         #    extent = [57000, 58000, 378000, 379000]
         return extent
 
-    cachedir = os.path.join(tempfile.tempdir, "test_download_watercourses")
+    cachedir = os.path.join(util.get_model_data_dir(), "test_download_watercourses")
     if not os.path.isdir(cachedir):
         os.makedirs(cachedir)
 

--- a/tests/test_009_layers.py
+++ b/tests/test_009_layers.py
@@ -9,12 +9,15 @@ from shapely.geometry import LineString
 
 import nlmod
 from nlmod.plot import DatasetCrossSection
+import util
+
+MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
 
 
 def get_regis_horstermeer(cachedir=None, cachename="regis_horstermeer"):
     extent = [131000, 136800, 471500, 475700]
     if cachedir is None:
-        cachedir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
+        cachedir = os.path.join(util.get_model_data_dir(), "regis_cache")
     if not os.path.isdir(cachedir):
         os.makedirs(cachedir)
     regis = nlmod.read.download_regis(extent, cachedir=cachedir, cachename=cachename)
@@ -23,7 +26,7 @@ def get_regis_horstermeer(cachedir=None, cachename="regis_horstermeer"):
 
 def get_regis_unstructured():
     regis = get_regis_horstermeer()
-    cachedir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
+    cachedir = os.path.join(util.get_model_data_dir(), "regis_cache")
     if not os.path.isdir(cachedir):
         os.makedirs(cachedir)
     return nlmod.grid.refine(regis, cachedir)

--- a/tests/test_013_surface_water.py
+++ b/tests/test_013_surface_water.py
@@ -6,11 +6,12 @@ import numpy as np
 import pandas as pd
 
 import nlmod
+import util
 
 
 def get_ds_and_gdf():
     model_name = "sw"
-    model_ws = os.path.join("data", model_name)
+    model_ws = os.path.join(util.get_model_data_dir(), model_name)
     extent = [119000, 120000, 523000, 524000]
     ds = nlmod.get_ds(extent, model_ws=model_ws, model_name=model_name)
     ds = nlmod.time.set_ds_time(ds, time=[365.0], start=pd.Timestamp.today())
@@ -50,7 +51,7 @@ def test_get_seaonal_timeseries():
 
 def test_gdf_lake():
     model_name = "la"
-    model_ws = os.path.join("data", model_name)
+    model_ws = os.path.join(util.get_model_data_dir(), model_name)
     ds = nlmod.get_ds(
         [170000, 171000, 550000, 551000], model_ws=model_ws, model_name=model_name
     )

--- a/tests/test_014_gis.py
+++ b/tests/test_014_gis.py
@@ -17,8 +17,8 @@ def test_vertex_da_to_gdf():
 
 def test_ds_to_ugrid_nc_file():
     ds = util.get_ds_vertex()
-    fname = os.path.join("data", "ugrid_test.nc")
+    fname = os.path.join(util.get_model_data_dir(), "ugrid_test.nc")
     nlmod.gis.ds_to_ugrid_nc_file(ds, fname)
 
-    fname = os.path.join("data", "ugrid_test_qgis.nc")
+    fname = os.path.join(util.get_model_data_dir(), "ugrid_test_qgis.nc")
     nlmod.gis.ds_to_ugrid_nc_file(ds, fname, for_imod_qgis_plugin=True)

--- a/tests/test_015_gwf_output.py
+++ b/tests/test_015_gwf_output.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 import numpy as np
 import pytest
@@ -8,9 +7,6 @@ import test_001_model
 import nlmod
 from nlmod.dims.grid import refine
 from nlmod.gwf import get_budget_da, get_heads_da
-
-tmpdir = tempfile.gettempdir()
-tst_model_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
 grberror = "Cannot create budget data-array without grid information."
 

--- a/tests/test_015_gwf_output.py
+++ b/tests/test_015_gwf_output.py
@@ -11,14 +11,14 @@ from nlmod.gwf import get_budget_da, get_heads_da
 grberror = "Cannot create budget data-array without grid information."
 
 
-def test_create_small_model_grid_only(tmpdir, model_name="test"):
+def test_create_small_model_grid_only(tmp_path, model_name="test"):
     model_name = "test"
     extent = [98700.0, 99000.0, 489500.0, 489700.0]
     # extent, nrow, ncol = nlmod.read.regis.fit_extent_to_regis(extent, 100, 100)
     regis_geotop_ds = nlmod.read.regis.get_combined_layer_models(
         extent, regis_botm_layer="KRz5", use_regis=True, use_geotop=True
     )
-    model_ws = os.path.join(tmpdir, model_name)
+    model_ws = os.path.join(tmp_path, model_name)
     ds = nlmod.to_model_ds(
         regis_geotop_ds, model_name, model_ws, delr=100.0, delc=100.0
     )
@@ -211,7 +211,7 @@ def test_get_budget_da_from_file_unstructured_with_grb():
 
 
 def test_postprocess_head():
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model")
     head = nlmod.gwf.get_heads_da(ds)
 
     nlmod.gwf.calculate_gxg(head)
@@ -222,7 +222,7 @@ def test_postprocess_head():
 
 
 def test_get_flow_residuals():
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model")
     da = nlmod.gwf.output.get_flow_residuals(ds)
     assert "time" in da.dims
     da = nlmod.gwf.output.get_flow_residuals(ds, kstpkper=(0, 0))
@@ -230,7 +230,7 @@ def test_get_flow_residuals():
 
 
 def test_get_flow_lower_face():
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model")
     da = nlmod.gwf.output.get_flow_lower_face(ds)
     assert "time" in da.dims
     da = nlmod.gwf.output.get_flow_lower_face(ds, kstpkper=(0, 0))

--- a/tests/test_018_knmi_data_platform.py
+++ b/tests/test_018_knmi_data_platform.py
@@ -1,14 +1,14 @@
 # ruff: noqa: D103
+import shutil
 from pathlib import Path
 
 from xarray import Dataset
 
 from nlmod.read import knmi_data_platform
+import os
 
-data_path = Path(__file__).parent / "data"
 
-
-def test_download_multiple_nc_files() -> None:
+def test_download_multiple_nc_files(tmp_path) -> None:
     dataset_name = "EV24"
     dataset_version = "2"
 
@@ -24,11 +24,10 @@ def test_download_multiple_nc_files() -> None:
 
         # download the first file
         fnames = files[0:1]
-        dirname = "download"
         knmi_data_platform.download_files(
-            dataset_name, dataset_version, fnames, dirname=dirname
+            dataset_name, dataset_version, fnames, dirname=tmp_path
         )
-        file = Path(dirname) / fnames[0]
+        file = tmp_path / fnames[0]
         assert file.exists(), f"File {file} was not downloaded properly"
 
         ds = knmi_data_platform.read_nc(file)
@@ -37,7 +36,7 @@ def test_download_multiple_nc_files() -> None:
         print(f"Error in knmi_data_platform test: {e}")
 
 
-def test_download_read_zip_file() -> None:
+def test_download_read_zip_file(tmp_path) -> None:
     dataset_name = "rad_nl25_rac_mfbs_24h_netcdf4"
     dataset_version = "2.0"
     try:
@@ -46,35 +45,40 @@ def test_download_read_zip_file() -> None:
         assert len(files) > 0, "No files found"
 
         # download the last file
-        dirname = "download"
         fname = files[1]
         knmi_data_platform.download_file(
-            dataset_name, dataset_version, fname=fname, dirname=dirname
+            dataset_name, dataset_version, fname=fname, dirname=tmp_path
         )
-        file = Path(dirname) / fname
+        file = tmp_path / fname
         assert file.exists(), f"File {file} was not downloaded properly"
     except knmi_data_platform.KNMIDataPlatformError as e:
         print(f"Error in knmi_data_platform test: {e}")
 
 
-def test_read_zip_file() -> None:
-    fname = data_path / "KNMI_Data_Platform_NETCDF.zip"
+def test_read_zip_file(tmp_path) -> None:
+    src = Path(__file__).resolve().parent / "data" / "KNMI_Data_Platform_NETCDF.zip"
+    fname = tmp_path / src.name
+    shutil.copy2(src, fname)
     try:
-        _ = knmi_data_platform.read_dataset_from_zip(str(fname), hour=24)
+        _ = knmi_data_platform.read_dataset_from_zip(fname, hour=24)
     except RuntimeError:
         # allow RuntimeError for this test for now (2025-11-19)
         # locally this fail does not happen, and we cannot recreate it
         pass
 
 
-def test_read_h5() -> None:
-    fname = data_path / "KNMI_Data_Platform_H5.zip"
-    _ = knmi_data_platform.read_dataset_from_zip(str(fname))
+def test_read_h5(tmp_path) -> None:
+    src = Path(__file__).resolve().parent / "data" / "KNMI_Data_Platform_H5.zip"
+    fname = tmp_path / src.name
+    shutil.copy2(src, fname)
+    _ = knmi_data_platform.read_dataset_from_zip(fname)
 
 
-def test_read_grib() -> None:
-    fname = data_path / "KNMI_Data_Platform_GRIB.tar"
+def test_read_grib(tmp_path) -> None:
+    src = Path(__file__).resolve().parent / "data" / "KNMI_Data_Platform_GRIB.tar"
+    fname = tmp_path / src.name
+    shutil.copy2(src, fname)
     _ = knmi_data_platform.read_dataset_from_zip(
-        str(fname),
+        fname,
         filter_by_keys={"stepType": "instant", "typeOfLevel": "heightAboveGround"},
     )

--- a/tests/test_019_attributes_encodings.py
+++ b/tests/test_019_attributes_encodings.py
@@ -30,8 +30,8 @@ def test_encodings_float_as_int16():
     assert encodings["porosity"]["dtype"] == "int16", "dtype should be int16"
 
     # test writing to temporary netcdf file
-    with TemporaryDirectory() as tmpdir:
-        fp_test = os.path.join(tmpdir, "test2.nc")
+    with TemporaryDirectory() as tmp_path:
+        fp_test = os.path.join(tmp_path, "test2.nc")
         ds.to_netcdf(fp_test, encoding=encodings)
 
         with xr.open_dataset(fp_test, mask_and_scale=True) as ds2:
@@ -75,14 +75,14 @@ def test_encondings_inplace():
     )
 
     # test writing to temporary netcdf file
-    with TemporaryDirectory() as tmpdir:
-        fp_test = os.path.join(tmpdir, "test2.nc")
+    with TemporaryDirectory() as tmp_path:
+        fp_test = os.path.join(tmp_path, "test2.nc")
         ds.to_netcdf(fp_test, encoding=encodings)
 
         with xr.open_dataset(fp_test, mask_and_scale=True) as ds2:
             ds2.load()
 
-        fp_test_inplace = os.path.join(tmpdir, "test_inplace.nc")
+        fp_test_inplace = os.path.join(tmp_path, "test_inplace.nc")
         ds_inplace.to_netcdf(fp_test_inplace)
 
         with xr.open_dataset(fp_test_inplace, mask_and_scale=True) as ds_inplace2:

--- a/tests/test_021_nhi.py
+++ b/tests/test_021_nhi.py
@@ -1,6 +1,5 @@
 # ruff: noqa: D103
 import os
-import tempfile
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -10,11 +9,9 @@ import pytest
 
 import nlmod
 
-tmp_path = tempfile.gettempdir()
-
 
 @pytest.mark.slow
-def test_buisdrainage():
+def test_buisdrainage(tmp_path):
     model_ws = os.path.join(tmp_path, "buidrain")
     ds = nlmod.get_ds([110_000, 130_000, 435_000, 445_000], model_ws=model_ws)
     ds.update(nlmod.read.nhi.discretize_buisdrainage(ds))

--- a/tests/test_021_nhi.py
+++ b/tests/test_021_nhi.py
@@ -10,12 +10,12 @@ import pytest
 
 import nlmod
 
-tmpdir = tempfile.gettempdir()
+tmp_path = tempfile.gettempdir()
 
 
 @pytest.mark.slow
 def test_buisdrainage():
-    model_ws = os.path.join(tmpdir, "buidrain")
+    model_ws = os.path.join(tmp_path, "buidrain")
     ds = nlmod.get_ds([110_000, 130_000, 435_000, 445_000], model_ws=model_ws)
     ds = nlmod.read.nhi.add_buisdrainage(ds)
 

--- a/tests/test_021_nhi.py
+++ b/tests/test_021_nhi.py
@@ -17,7 +17,7 @@ tmp_path = tempfile.gettempdir()
 def test_buisdrainage():
     model_ws = os.path.join(tmp_path, "buidrain")
     ds = nlmod.get_ds([110_000, 130_000, 435_000, 445_000], model_ws=model_ws)
-    ds = nlmod.read.nhi.add_buisdrainage(ds)
+    ds.update(nlmod.read.nhi.discretize_buisdrainage(ds))
 
     # assert that all locations with a specified depth also have a positive conductance
     mask = ~ds["buisdrain_depth"].isnull()
@@ -34,13 +34,13 @@ def test_gwo():
 
     # download all wells from Brabant Water
     try:
-        wells = nlmod.read.nhi.get_gwo_wells(
+        wells = nlmod.read.nhi.download_gwo_wells(
             username=username, password=password, organisation="Brabant Water"
         )
         assert isinstance(wells, gpd.GeoDataFrame)
 
         # download extractions from well "13-PP016" of pomping station Veghel
-        measurements, gdf = nlmod.read.nhi.get_gwo_measurements(
+        measurements, gdf = nlmod.read.nhi.download_gwo_measurements(
             username, password, well_site="veghel", filter__well__name="13-PP016"
         )
         assert measurements.reset_index()["Name"].isin(gdf.index).all()
@@ -59,7 +59,7 @@ def allow_network_fail(e):
 def test_gwo_entire_pumping_station():
     username = os.environ["NHI_GWO_USERNAME"]
     password = os.environ["NHI_GWO_PASSWORD"]
-    measurements, gdf = nlmod.read.nhi.get_gwo_measurements(
+    measurements, gdf = nlmod.read.nhi.download_gwo_measurements(
         username,
         password,
         well_site="veghel",

--- a/tests/test_021_nhi.py
+++ b/tests/test_021_nhi.py
@@ -69,11 +69,15 @@ def test_gwo_entire_pumping_station():
     ncols = 3
     nrows = int(np.ceil(len(gdf.index) / ncols))
     f, axes = plt.subplots(
-        nrows=nrows, ncols=ncols, figsize=(10, 10), sharex=True, sharey=True
+        nrows=nrows,
+        ncols=ncols,
+        figsize=(10, 10),
+        sharex=True,
+        sharey=True,
+        layout="constrained",
     )
     axes = axes.ravel()
     for name, ax in zip(gdf.index, axes):
         measurements.loc[name, "Volume"].plot(ax=ax)
         ax.set_xlabel("")
         ax.set_title(name)
-    f.tight_layout(pad=0.0)

--- a/tests/test_022_gwt.py
+++ b/tests/test_022_gwt.py
@@ -10,9 +10,9 @@ import nlmod
 def test_gwt_model():
     extent = [103700, 106700, 527500, 528500]
 
-    tmpdir = tempfile.gettempdir()
+    tmp_path = tempfile.gettempdir()
     model_name = "trnsprt_tst"
-    model_ws = os.path.join(tmpdir, model_name)
+    model_ws = os.path.join(tmp_path, model_name)
 
     layer_model = nlmod.read.download_regis(extent, botm_layer="MSz1")
     # create a model ds

--- a/tests/test_022_gwt.py
+++ b/tests/test_022_gwt.py
@@ -1,18 +1,17 @@
 import os
-import tempfile
 
 import pandas as pd
 import xarray as xr
 
 import nlmod
+import util
 
 
 def test_gwt_model():
     extent = [103700, 106700, 527500, 528500]
 
-    tmp_path = tempfile.gettempdir()
     model_name = "trnsprt_tst"
-    model_ws = os.path.join(tmp_path, model_name)
+    model_ws = os.path.join(util.get_model_data_dir(), model_name)
 
     layer_model = nlmod.read.download_regis(extent, botm_layer="MSz1")
     # create a model ds

--- a/tests/test_023_hfb.py
+++ b/tests/test_023_hfb.py
@@ -1,4 +1,8 @@
 # ruff: noqa: D103
+import matplotlib
+
+matplotlib.use("Agg")
+
 import flopy
 import geopandas as gpd
 import util

--- a/tests/test_024_administrative.py
+++ b/tests/test_024_administrative.py
@@ -38,6 +38,12 @@ def test_get_netherlands_kadaster():
     assert len(gdf) > 0
 
 
+def test_download_kadaster_percelen():
+    extent = [118_200, 118_300, 439_800, 439_900]
+    gdf = nlmod.read.administrative.download_kadaster_percelen(extent=extent)
+    assert len(gdf) > 0
+
+
 def test_get_waterboards():
     try:
         gdf = nlmod.read.administrative.download_waterboards_gdf()

--- a/tests/test_024_administrative.py
+++ b/tests/test_024_administrative.py
@@ -12,7 +12,9 @@ def test_get_municipalities_cbs():
 
 def test_get_municipalities_kadaster():
     extent = [100000, 110000, 400000, 410000]
-    gdf = nlmod.read.administrative.download_municipalities_gdf(source="kadaster", extent=extent)
+    gdf = nlmod.read.administrative.download_municipalities_gdf(
+        source="kadaster", extent=extent
+    )
     assert len(gdf) > 0
 
 

--- a/tests/test_024_administrative.py
+++ b/tests/test_024_administrative.py
@@ -1,3 +1,6 @@
+import requests
+import pytest
+
 import nlmod
 
 
@@ -34,5 +37,8 @@ def test_get_netherlands_kadaster():
 
 
 def test_get_waterboards():
-    gdf = nlmod.read.administrative.download_waterboards_gdf()
-    assert len(gdf) > 0
+    try:
+        gdf = nlmod.read.administrative.download_waterboards_gdf()
+        assert len(gdf) > 0
+    except requests.exceptions.RequestException as exc:
+        pytest.skip(f"Network unavailable: {exc}")

--- a/tests/test_025_modpath.py
+++ b/tests/test_025_modpath.py
@@ -8,7 +8,7 @@ import nlmod
 
 def test_modpath():
     # start with runned model from test_001_model.test_create_sea_model
-    ds = test_001_model.get_ds_from_cache("basic_sea_model")
+    ds = test_001_model.get_ds_from_cache("sea_model")
 
     sim = flopy.mf6.MFSimulation.load("mfsim.nam", sim_ws=ds.model_ws)
     gwf = sim.get_model(ds.model_name)

--- a/tests/test_025_modpath.py
+++ b/tests/test_025_modpath.py
@@ -40,7 +40,7 @@ def test_modpath():
     nlmod.modpath.load_pathline_data(mpf)
 
     # get the nodes from a package
-    nodes = nlmod.modpath.package_to_nodes(gwf, "GHB", mpf)
+    nodes = nlmod.modpath.package_to_nodes(gwf, "GHB", ibound=mpf.ib)
 
     # get nodes of all cells in the top modellayer
     nodes = nlmod.modpath.layer_to_nodes(mpf, 0)

--- a/tests/test_025_modpath.py
+++ b/tests/test_025_modpath.py
@@ -1,15 +1,14 @@
 import os
 
 import flopy
-import xarray as xr
+import test_001_model
 
 import nlmod
 
 
 def test_modpath():
     # start with runned model from test_001_model.test_create_sea_model
-    model_ws = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
-    ds = xr.open_dataset(os.path.join(model_ws, "basic_sea_model.nc"))
+    ds = test_001_model.get_ds_from_cache("basic_sea_model")
 
     sim = flopy.mf6.MFSimulation.load("mfsim.nam", sim_ws=ds.model_ws)
     gwf = sim.get_model(ds.model_name)

--- a/tests/test_026_grid.py
+++ b/tests/test_026_grid.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -7,8 +6,9 @@ import numpy as np
 import xarray as xr
 
 import nlmod
+import util
 
-model_ws = os.path.join(tempfile.gettempdir(), "test_grid")
+model_ws = os.path.join(util.get_model_data_dir(), "test_grid")
 extent = [98000.0, 99000.0, 489000.0, 490000.0]
 
 
@@ -33,7 +33,7 @@ def get_regis():
 
 
 def get_structured_model_ds():
-    model_ws = os.path.join(tempfile.gettempdir(), "test_grid_structured")
+    model_ws = os.path.join(util.get_model_data_dir(), "test_grid_structured")
     fname = os.path.join(model_ws, "ds.nc")
     if not os.path.isfile(fname):
         if not os.path.isdir(model_ws):
@@ -44,7 +44,7 @@ def get_structured_model_ds():
 
 
 def get_structured_model_ds_rotated():
-    model_ws = os.path.join(tempfile.gettempdir(), "test_grid_structured_rotated")
+    model_ws = os.path.join(util.get_model_data_dir(), "test_grid_structured_rotated")
     fname = os.path.join(model_ws, "ds.nc")
     if not os.path.isfile(fname):
         if not os.path.isdir(model_ws):
@@ -55,7 +55,7 @@ def get_structured_model_ds_rotated():
 
 
 def get_vertex_model_ds(bgt=None):
-    model_ws = os.path.join(tempfile.gettempdir(), "test_grid_vertex")
+    model_ws = os.path.join(util.get_model_data_dir(), "test_grid_vertex")
     fname = os.path.join(model_ws, "ds.nc")
     if not os.path.isfile(fname):
         if not os.path.isdir(model_ws):
@@ -69,7 +69,7 @@ def get_vertex_model_ds(bgt=None):
 
 
 def get_vertex_model_ds_rotated(bgt=None):
-    model_ws = os.path.join(tempfile.gettempdir(), "test_grid_vertex_rotated")
+    model_ws = os.path.join(util.get_model_data_dir(), "test_grid_vertex_rotated")
     fname = os.path.join(model_ws, "ds.nc")
     if not os.path.isfile(fname):
         if not os.path.isdir(model_ws):
@@ -380,7 +380,7 @@ def test_update_ds_from_layer_ds():
     assert len(np.unique(ds["top"])) > 1
 
     # test for a vertex grid
-    model_ws = os.path.join(tempfile.gettempdir(), "test_grid_vertex_200")
+    model_ws = os.path.join(util.get_model_data_dir(), "test_grid_vertex_200")
     ds = nlmod.grid.refine(ds, model_ws=model_ws, refinement_features=[(bgt, 1)])
     ds = nlmod.grid.update_ds_from_layer_ds(ds, regis, method="nearest")
     assert len(np.unique(ds["top"])) > 1
@@ -395,7 +395,7 @@ def test_update_ds_from_layer_ds():
     assert len(np.unique(ds["top"])) > 1
 
     # test for a rotated vertex grid
-    model_ws = os.path.join(tempfile.gettempdir(), "test_grid_vertex_200_rotated")
+    model_ws = os.path.join(util.get_model_data_dir(), "test_grid_vertex_200_rotated")
     ds = nlmod.grid.refine(ds, model_ws=model_ws, refinement_features=[(bgt, 2)])
     ds = nlmod.grid.update_ds_from_layer_ds(ds, regis, method="nearest")
     assert len(np.unique(ds["top"])) > 1

--- a/tests/test_027_util.py
+++ b/tests/test_027_util.py
@@ -1,12 +1,12 @@
 import os
-import tempfile
 
 import geopandas as gpd
 import rioxarray
 
 import nlmod
+import util
 
-model_ws = os.path.join(tempfile.gettempdir(), "test_util")
+model_ws = os.path.join(util.get_model_data_dir(), "test_util")
 extent = [98000.0, 99000.0, 489000.0, 490000.0]
 
 

--- a/tests/test_029_bgt.py
+++ b/tests/test_029_bgt.py
@@ -1,5 +1,3 @@
-import os
-
 import requests
 from lxml import html
 from pandas import to_datetime
@@ -29,11 +27,8 @@ def test_bgt_layers():
     assert "waterdeel" in layers
 
 
-def test_bgt_zipfile():
-    pathname = "download"
-    if not os.path.isdir(pathname):
-        os.makedirs(pathname)
-    fname = os.path.join(pathname, "test_bgt_zipfile.zip")
+def test_bgt_zipfile(tmp_path):
+    fname = tmp_path / "test_bgt_zipfile.zip"
 
     # download data from 2 layers within extent, and also save data to zipfile
     extent = [119900, 120000, 440000, 440100]

--- a/tests/test_032_config_version.py
+++ b/tests/test_032_config_version.py
@@ -47,9 +47,7 @@ def test_cache_options_restores_on_exception():
         with config.cache_options(explicit_dataset_coordinate_comparison=not original):
             raise RuntimeError("boom")
 
-    assert (
-        config.get_options()["explicit_dataset_coordinate_comparison"] is original
-    )
+    assert config.get_options()["explicit_dataset_coordinate_comparison"] is original
 
 
 def test_show_versions_prints_expected_lines(capsys):

--- a/tests/test_032_config_version.py
+++ b/tests/test_032_config_version.py
@@ -1,0 +1,64 @@
+import pytest
+
+from nlmod import config
+from nlmod.version import __version__, show_versions
+
+
+@pytest.fixture(autouse=True)
+def reset_config_options_after_test():
+    config.reset_options()
+    yield
+    config.reset_options()
+
+
+def test_set_get_and_reset_options():
+    config.set_options(nc_hash=False, dataset_coords_hash=False)
+
+    assert config.get_options("nc_hash") == {"nc_hash": False}
+    assert config.get_options("dataset_coords_hash") == {
+        "dataset_coords_hash": False,
+    }
+
+    config.reset_options(["nc_hash", "dataset_coords_hash"])
+    assert config.get_options("nc_hash") == {"nc_hash": True}
+    assert config.get_options("dataset_coords_hash") == {
+        "dataset_coords_hash": True,
+    }
+
+
+def test_set_options_unknown_key_raises():
+    with pytest.raises(ValueError, match="Unknown option"):
+        config.set_options(does_not_exist=True)
+
+
+def test_cache_options_context_restores_on_exit():
+    original = config.get_options()["dataset_data_vars_hash"]
+
+    with config.cache_options(dataset_data_vars_hash=not original) as opts:
+        assert opts["dataset_data_vars_hash"] is (not original)
+
+    assert config.get_options()["dataset_data_vars_hash"] is original
+
+
+def test_cache_options_restores_on_exception():
+    original = config.get_options()["explicit_dataset_coordinate_comparison"]
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with config.cache_options(explicit_dataset_coordinate_comparison=not original):
+            raise RuntimeError("boom")
+
+    assert (
+        config.get_options()["explicit_dataset_coordinate_comparison"] is original
+    )
+
+
+def test_show_versions_prints_expected_lines(capsys):
+    show_versions()
+    out = capsys.readouterr().out
+
+    assert "Python version" in out
+    assert "NumPy version" in out
+    assert "Xarray version" in out
+    assert "Matplotlib version" in out
+    assert "Flopy version" in out
+    assert f"nlmod version      : {__version__}" in out

--- a/tests/test_033_additional_cases.py
+++ b/tests/test_033_additional_cases.py
@@ -84,7 +84,9 @@ def test_webservices_get_data_non_json_propagates_value_error(monkeypatch):
         def json(self):
             raise ValueError("not json")
 
-    monkeypatch.setattr(webservices.requests, "get", lambda *args, **kwargs: DummyResponse())
+    monkeypatch.setattr(
+        webservices.requests, "get", lambda *args, **kwargs: DummyResponse()
+    )
 
     with pytest.raises(ValueError, match="not json"):
         webservices._get_data("https://example.test", {})
@@ -95,7 +97,9 @@ def test_webservices_get_data_http_error_on_bad_status(monkeypatch):
         ok = False
         url = "https://example.test"
 
-    monkeypatch.setattr(webservices.requests, "get", lambda *args, **kwargs: DummyResponse())
+    monkeypatch.setattr(
+        webservices.requests, "get", lambda *args, **kwargs: DummyResponse()
+    )
 
     with pytest.raises(HTTPError, match="Request not successful"):
         webservices._get_data("https://example.test", {})
@@ -109,7 +113,9 @@ def test_webservices_get_data_error_payload_raises(monkeypatch):
         def json(self):
             return {"error": {"code": 500, "message": "boom"}}
 
-    monkeypatch.setattr(webservices.requests, "get", lambda *args, **kwargs: DummyResponse())
+    monkeypatch.setattr(
+        webservices.requests, "get", lambda *args, **kwargs: DummyResponse()
+    )
 
     with pytest.raises(ValueError, match="Error code 500"):
         webservices._get_data("https://example.test", {})

--- a/tests/test_033_additional_cases.py
+++ b/tests/test_033_additional_cases.py
@@ -1,0 +1,263 @@
+import cftime
+import geopandas as gpd
+import numpy as np
+import pytest
+import xarray as xr
+from requests.exceptions import HTTPError, RequestException
+from shapely.geometry import Polygon
+
+import nlmod
+from nlmod import config
+from nlmod.dims.layers import kveq_combined_layers
+from nlmod.modpath.modpath import package_to_nodes
+from nlmod.read import administrative, knmi_data_platform, webservices
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_options():
+    config.reset_options()
+    yield
+    config.reset_options()
+
+
+def test_config_reset_unknown_key_raises_keyerror():
+    with pytest.raises(KeyError):
+        config.reset_options(["does_not_exist"])
+
+
+def test_config_get_options_shape_contract():
+    all_opts = config.get_options()
+    one_opt = config.get_options("nc_hash")
+
+    assert isinstance(all_opts, dict)
+    assert set(one_opt) == {"nc_hash"}
+    assert isinstance(one_opt["nc_hash"], bool)
+
+
+def test_set_ds_time_mixed_string_formats():
+    ds = nlmod.get_ds([0, 100, 0, 100])
+    out = nlmod.time.set_ds_time(
+        ds,
+        start="2000-01-01",
+        time=["2000-02-01", "2000/03/01"],
+    )
+
+    assert out.sizes["time"] == 2
+    assert out.time.values[1] > out.time.values[0]
+
+
+def test_set_ds_time_mixed_formats_with_cftime_start():
+    ds = nlmod.get_ds([0, 100, 0, 100])
+    out = nlmod.time.set_ds_time(
+        ds,
+        start=cftime.datetime(1000, 1, 1),
+        time=["2000-02-01", "2000/03/01"],
+    )
+
+    assert isinstance(out.time.values[0], cftime.datetime)
+    assert out.time.values[1] > out.time.values[0]
+
+
+def test_kveq_combined_layers_zero_denominator_returns_nan():
+    kv = xr.DataArray(
+        np.array(
+            [
+                [[1.0, np.inf]],
+                [[1.0, np.inf]],
+            ]
+        ),
+        dims=("layer", "y", "x"),
+    )
+    thickness = xr.DataArray(np.ones_like(kv), dims=kv.dims)
+
+    out = kveq_combined_layers(kv, thickness, {0: (0, 1)})
+
+    assert np.isfinite(out.data[0, 0, 0])
+    assert np.isnan(out.data[0, 0, 1])
+
+
+def test_webservices_get_data_non_json_propagates_value_error(monkeypatch):
+    class DummyResponse:
+        ok = True
+        url = "https://example.test"
+
+        def json(self):
+            raise ValueError("not json")
+
+    monkeypatch.setattr(webservices.requests, "get", lambda *args, **kwargs: DummyResponse())
+
+    with pytest.raises(ValueError, match="not json"):
+        webservices._get_data("https://example.test", {})
+
+
+def test_webservices_get_data_http_error_on_bad_status(monkeypatch):
+    class DummyResponse:
+        ok = False
+        url = "https://example.test"
+
+    monkeypatch.setattr(webservices.requests, "get", lambda *args, **kwargs: DummyResponse())
+
+    with pytest.raises(HTTPError, match="Request not successful"):
+        webservices._get_data("https://example.test", {})
+
+
+def test_webservices_get_data_error_payload_raises(monkeypatch):
+    class DummyResponse:
+        ok = True
+        url = "https://example.test"
+
+        def json(self):
+            return {"error": {"code": 500, "message": "boom"}}
+
+    monkeypatch.setattr(webservices.requests, "get", lambda *args, **kwargs: DummyResponse())
+
+    with pytest.raises(ValueError, match="Error code 500"):
+        webservices._get_data("https://example.test", {})
+
+
+def test_administrative_wfs_request_exception_propagates(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise RequestException("network down")
+
+    monkeypatch.setattr(administrative.webservices, "wfs", _raise)
+
+    with pytest.raises(RequestException, match="network down"):
+        administrative.download_municipalities_gdf(source="cbs", cachename="muni_exc")
+    with pytest.raises(RequestException, match="network down"):
+        administrative.download_provinces_gdf(source="cbs", cachename="prov_exc")
+    with pytest.raises(RequestException, match="network down"):
+        administrative.download_netherlands_gdf(source="cbs", cachename="nl_exc")
+
+
+def test_administrative_waterboards_request_exception_propagates(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise RequestException("network down")
+
+    monkeypatch.setattr(administrative.waterboard, "download_polygons", _raise)
+
+    with pytest.raises(RequestException, match="network down"):
+        administrative.download_waterboards_gdf(cachename="wb_exc")
+
+
+def test_knmi_download_file_accepts_pathlike(monkeypatch, tmp_path):
+    class JsonResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class StreamResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size=8192):
+            yield b"abc"
+
+    def fake_get(url, *args, **kwargs):
+        if str(url).endswith("/url"):
+            return JsonResponse({"temporaryDownloadUrl": "https://download.test/file"})
+        return StreamResponse()
+
+    monkeypatch.setattr(knmi_data_platform.requests, "get", fake_get)
+
+    knmi_data_platform.download_file(
+        dataset_name="dummy",
+        dataset_version="1",
+        fname="file.bin",
+        dirname=tmp_path,
+        api_key="token",
+    )
+
+    assert (tmp_path / "file.bin").exists()
+
+
+def test_knmi_download_files_forwards_pathlike(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_download_file(*, dirname, **kwargs):
+        calls.append(dirname)
+
+    monkeypatch.setattr(knmi_data_platform, "download_file", fake_download_file)
+
+    knmi_data_platform.download_files(
+        dataset_name="dummy",
+        dataset_version="1",
+        fnames=["a.bin", "b.bin"],
+        dirname=tmp_path,
+        api_key="token",
+    )
+
+    assert calls == [tmp_path, tmp_path]
+
+
+def test_surface_water_discretize_missing_columns_raises_keyerror():
+    ds = nlmod.get_ds(
+        [0, 100, 0, 100],
+        delr=50.0,
+        delc=50.0,
+        top=1.0,
+        botm=[0.0],
+        kh=1.0,
+        kv=1.0,
+    )
+    gdf = gpd.GeoDataFrame(
+        {"geometry": [Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])]},
+        geometry="geometry",
+        crs=28992,
+    )
+
+    with pytest.raises(KeyError):
+        nlmod.read.rws.discretize_surface_water(ds, gdf, da_basename="sw")
+
+
+def test_modpath_package_to_nodes_without_ibound_structured_and_vertex():
+    class DummyConnData:
+        def __init__(self, cellids):
+            self.array = {"cellid": cellids}
+
+    class DummyPackage:
+        def __init__(self, cellids):
+            self.connectiondata = DummyConnData(cellids)
+
+    class DummyGrid:
+        def __init__(self, grid_type, shape):
+            self.grid_type = grid_type
+            self.shape = shape
+
+    class DummyGwf:
+        def __init__(self, grid_type, shape, cellids):
+            self.modelgrid = DummyGrid(grid_type, shape)
+            self._pkg = DummyPackage(cellids)
+
+        def get_package(self, name):
+            return self._pkg
+
+    gwf_struct = DummyGwf("structured", (1, 2, 3), [(0, 0, 0), (0, 1, 2)])
+    nodes_struct = package_to_nodes(gwf_struct, "GHB")
+    assert nodes_struct == [0, 5]
+
+    gwf_vertex = DummyGwf("vertex", (2, 4), [(0, 0), (1, 3)])
+    nodes_vertex = package_to_nodes(gwf_vertex, "GHB")
+    assert nodes_vertex == [0, 7]
+
+
+def test_show_versions_propagates_missing_dependency(monkeypatch):
+    from importlib import metadata
+    from nlmod import version as version_module
+
+    def fake_version(name):
+        if name == "numpy":
+            raise metadata.PackageNotFoundError("numpy")
+        return "1.0"
+
+    monkeypatch.setattr(version_module.metadata, "version", fake_version)
+
+    with pytest.raises(metadata.PackageNotFoundError):
+        version_module.show_versions()

--- a/tests/test_034_interactive_env.py
+++ b/tests/test_034_interactive_env.py
@@ -1,0 +1,12 @@
+import os
+
+import util
+
+
+def test_model_data_dir_fallback_for_interactive(monkeypatch):
+    monkeypatch.delenv("NLMOD_TEST_MODEL_DATA_DIR", raising=False)
+
+    model_data_dir = util.get_model_data_dir()
+
+    assert os.path.isdir(model_data_dir)
+    assert os.environ.get("NLMOD_TEST_MODEL_DATA_DIR") == model_data_dir

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from shapely.geometry import LineString
 
@@ -10,11 +11,12 @@ MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
 def get_model_data_dir():
     model_data_dir = os.environ.get(MODEL_DATA_ENV_VAR)
     if model_data_dir is None:
-        raise RuntimeError(
-            f"Environment variable {MODEL_DATA_ENV_VAR} is not set. "
-            "Run tests via pytest so tests/conftest.py can configure "
-            "the shared model-data directory."
+        # In interactive windows there is no pytest fixture lifecycle, so provide
+        # a deterministic temp fallback to make single-test debugging possible.
+        model_data_dir = os.path.join(
+            tempfile.gettempdir(), "nlmod_test_model_data_interactive"
         )
+        os.environ[MODEL_DATA_ENV_VAR] = model_data_dir
     os.makedirs(model_data_dir, exist_ok=True)
     return model_data_dir
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,11 +4,25 @@ from shapely.geometry import LineString
 
 import nlmod
 
+MODEL_DATA_ENV_VAR = "NLMOD_TEST_MODEL_DATA_DIR"
+
+
+def get_model_data_dir():
+    model_data_dir = os.environ.get(MODEL_DATA_ENV_VAR)
+    if model_data_dir is None:
+        raise RuntimeError(
+            f"Environment variable {MODEL_DATA_ENV_VAR} is not set. "
+            "Run tests via pytest so tests/conftest.py can configure "
+            "the shared model-data directory."
+        )
+    os.makedirs(model_data_dir, exist_ok=True)
+    return model_data_dir
+
 
 def get_ds_structured(extent=None, model_name="test", **kwargs):
     if extent is None:
         extent = [0, 1000, 0, 1000]
-    model_ws = os.path.join("data", model_name)
+    model_ws = os.path.join(get_model_data_dir(), model_name)
     ds = nlmod.get_ds(extent, model_name=model_name, model_ws=model_ws, **kwargs)
     return ds
 
@@ -17,7 +31,7 @@ def get_ds_vertex(extent=None, line=None, **kwargs):
     if line is None:
         line = [(0, 1000), (1000, 0)]
     ds = get_ds_structured(extent=extent, **kwargs)
-    model_ws = os.path.join("data", "gridgen")
+    model_ws = os.path.join(get_model_data_dir(), "gridgen")
     refinement_features = [([LineString(line)], "line", 1)]
     ds = nlmod.grid.refine(ds, model_ws, refinement_features=refinement_features)
     return ds


### PR DESCRIPTION
This PR makes sure notebooks and tests produce output in folder that are not committed to Git:
- the models in the notebooks are run in a folder with the same name as the notebook. we make sure this folder is included in gitignore.
- the tests are run inside a temporary folder that is written to an environmental variable, so it can be used by other tests. This environmental variable is created when test are created outside pytest.

Also this PR improves some tests:
- remove 3 of the sea_model tests in test_001_model.py, as these tests only add 3 extra covered lines, have a lot of duplicate code and take a long time.
- Use `tmp_path` instead of `tmpdir`
- Fix some of the warnings pytest shows
- Make sure to close all figures and close handles to netcdf file at every test (in conftest.py). This might have been the reason for the freezed tests before.
- Add extra tests using copilot
- add test for `nlmod.read.administrative.download_kadaster_percelen`
- do not use deprecated methods in anymore, but use the replacements (`download_` instead of `get_`)

Some other changes:
- remove broken 'year' argument in `download_percelen_gdf`
- remove tight_layout where applicable from plot-methods
- add custom.css so dataframes in documenttaion look nice again (after the update of myst-nb)