### PR TITLE
added 'na_filter=False' to read_csv in read_gleg in nlmod.read.regis.py

### DIFF
--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -532,6 +532,7 @@ def read_gleg(fname):
         sep="\t",
         header=None,
         names=["naam", "beschrijving", "r", "g", "b", "a", "x"],
+        na_filter=False,
     )
     leg["naam"] = leg["naam"].str.replace("-", "")
     leg.set_index("naam", inplace=True)


### PR DESCRIPTION
Suggest to add na_filter=False to pd.read_csv() in read_gleg. Otherwise the code for the "Formatie van Naaldwijk", which is "NA",  mistakenly gets recognized as a nan value.