### PR TITLE
Add HFB package builder from dataframes

### DIFF
--- a/nlmod/gwf/hfb.py
+++ b/nlmod/gwf/hfb.py
@@ -29,6 +29,7 @@ def hfb_from_df(
     df,
     gwf,
     ds,
+    *,
     hydchr="hydchr",
     depth="depth",
     elevation="elevation",
@@ -80,7 +81,7 @@ def hfb_from_df(
     if unsupported:
         raise ValueError(
             "hfb_from_df supports only LineString and MultiLineString geometries; "
-            f"found {sorted(unsupported)}"
+            f"found {sorted(unsupported)}",
         )
 
     spd = []
@@ -90,7 +91,7 @@ def hfb_from_df(
             raise ValueError(f"hydchr must be set for HFB feature at index {index!r}")
         if hydchr_value <= 0:
             raise ValueError(
-                f"hydchr must be positive for HFB feature at index {index!r}"
+                f"hydchr must be positive for HFB feature at index {index!r}",
             )
 
         depth_value = _get_optional_hfb_value(row, depth, "depth", index)
@@ -98,7 +99,7 @@ def hfb_from_df(
         if (depth_value is None) == (elevation_value is None):
             raise ValueError(
                 "Exactly one of depth or elevation must be set for HFB feature "
-                f"at index {index!r}"
+                f"at index {index!r}",
             )
 
         feature = df.iloc[[row_number]]
@@ -106,7 +107,10 @@ def hfb_from_df(
             spd += get_hfb_spd(ds, feature, hydchr=hydchr_value, depth=depth_value)
         else:
             spd += get_hfb_spd(
-                ds, feature, hydchr=hydchr_value, elevation=elevation_value
+                ds,
+                feature,
+                hydchr=hydchr_value,
+                elevation=elevation_value,
             )
 
     spd = _clean_hfb_spd(spd)
@@ -131,7 +135,7 @@ def _get_optional_hfb_value(row, value_or_column, name, index):
         if value_or_column not in row.index:
             raise KeyError(
                 f"Column {value_or_column!r} not found for {name} of HFB feature "
-                f"at index {index!r}"
+                f"at index {index!r}",
             )
         value = row[value_or_column]
     else:
@@ -235,18 +239,17 @@ def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
                     spd.append([cellid1, cellid2, hydchr * hydchr_frac])
                     break  # go to next cell
 
+            elif topi[ilay + 1] >= elevation:
+                # hfb spans the entire cell
+                spd.append([cellid1, cellid2, hydchr])
+
             else:
-                if topi[ilay + 1] >= elevation:
-                    # hfb spans the entire cell
-                    spd.append([cellid1, cellid2, hydchr])
+                # hfb spans the cell partially
+                hydchr_frac = (topi[ilay] - elevation) / thicki[ilay]
+                assert 0 <= hydchr_frac <= 1, "Something is wrong"
 
-                else:
-                    # hfb spans the cell partially
-                    hydchr_frac = (topi[ilay] - elevation) / thicki[ilay]
-                    assert 0 <= hydchr_frac <= 1, "Something is wrong"
-
-                    spd.append([cellid1, cellid2, hydchr * hydchr_frac])
-                    break  # go to next cell
+                spd.append([cellid1, cellid2, hydchr * hydchr_frac])
+                break  # go to next cell
 
     return spd
 
@@ -306,13 +309,13 @@ def line_to_hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
         else:
             raise TypeError(
                 "Please pass either a flopy.discretization.grid.Grid or "
-                "flopy.mf6.ModflowGwf object as gwf."
+                "flopy.mf6.ModflowGwf object as gwf.",
             )
     elif ds is not None:
         mgrid = modelgrid_from_ds(ds)
     else:
         raise ValueError(
-            "Please pass either a dataset or a flopy.mf6.ModflowGwf object."
+            "Please pass either a dataset or a flopy.mf6.ModflowGwf object.",
         )
 
     gdfg = gdf_to_grid(gdf, gwf if gwf is not None else ds, desc="Intersecting HFB(s)")
@@ -332,15 +335,17 @@ def line_to_hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
         cell2d.index.name = "icell2d"
         icvert = np.array(
             [
-                mgrid._build_structured_iverts(*mgrid.get_lrc(icpl)[0][1:])
+                mgrid._build_structured_iverts(  # pylint: disable=protected-access
+                    *mgrid.get_lrc(icpl)[0][1:],
+                )
                 for icpl in range(mgrid.ncpl)
-            ]
+            ],
         )
         # add first vertex to the end of the list
         icvert = np.hstack([icvert, icvert[:, :1]])
         gdfg["cellid_structured"] = gdfg["cellid"]
         gdfg["cellid"] = gdfg["cellid"].map(
-            lambda cid: get_node_structured(0, *cid, shape=mgrid.shape)
+            lambda cid: get_node_structured(0, *cid, shape=mgrid.shape),
         )
     elif mgrid.grid_type == "vertex":
         cell2d = pd.DataFrame(mgrid.cell2d)
@@ -358,7 +363,7 @@ def line_to_hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
     else:
         raise ValueError(
             f"gridtype {mgrid.grid_type} not supported. Only 'structured' "
-            "and 'vertex' are supported."
+            "and 'vertex' are supported.",
         )
 
     # for every cell determine which cell-edge could form the line
@@ -504,7 +509,7 @@ def line_to_hfb_buffer(gdf, ds, buffer_distance=None, gi=None):
     if buffer_distance is None:
         # buffer distance ~ 1.5 * max cell size
         buffer_distance = 1.5 * np.max(
-            [np.max(np.abs(np.diff(ds["x"]))), np.max(np.abs(np.diff(ds["y"])))]
+            [np.max(np.abs(np.diff(ds["x"]))), np.max(np.abs(np.diff(ds["y"])))],
         )
 
     zone_left = gdf.buffer(-buffer_distance, single_sided=True)
@@ -519,7 +524,7 @@ def line_to_hfb_buffer(gdf, ds, buffer_distance=None, gi=None):
         logger.warning(
             "The left and right buffer zones intersect. Please check your input."
             "Perhaps there are multiple linestrings, or the linestring geometry is "
-            "causing potential issues. You can also try modifying the buffer_distance."
+            "causing potential issues. You can also try modifying the buffer_distance.",
         )
     zone_gdf = pd.concat([zone_left, zone_right], axis=0).reset_index(drop=True)
 
@@ -542,13 +547,20 @@ def line_to_hfb_buffer(gdf, ds, buffer_distance=None, gi=None):
     else:
         raise ValueError(
             f"gridtype {mgrid.grid_type} not supported. Only 'structured' "
-            "and 'vertex' are supported."
+            "and 'vertex' are supported.",
         )
     return hfb_seg
 
 
-def polygon_to_hfb(
-    gdf, ds, hydchr, column=None, gwf=None, lay=0, add_data=False, include_nan=True
+def polygon_to_hfb(  # pylint: disable=too-many-positional-arguments
+    gdf,
+    ds,
+    hydchr,
+    column=None,
+    gwf=None,
+    lay=0,
+    add_data=False,
+    include_nan=True,
 ):
     """Snap polygon exterior to grid to form a horizontal flow barrier.
 
@@ -637,8 +649,7 @@ def polygon_to_hfb(
                 spd[-1].extend([data[icell2d1], data[icell2d2]])
     if gwf is None:
         return spd
-    else:
-        return flopy.mf6.ModflowGwfhfb(gwf, stress_period_data={0: spd})
+    return flopy.mf6.ModflowGwfhfb(gwf, stress_period_data={0: spd})
 
 
 def plot_hfb(cellids, modelgrid, ax=None, color="red", **kwargs):

--- a/nlmod/gwf/hfb.py
+++ b/nlmod/gwf/hfb.py
@@ -185,9 +185,8 @@ def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
     spd : List of Tuple
         Stress period data used to configure the hfb package of Flopy.
     """
-    assert sum([depth is None, elevation is None]) == 1, (
-        "Use either depth or elevation argument"
-    )
+    if (depth is None) == (elevation is None):
+        raise ValueError("Use either depth or elevation argument")
 
     if not isinstance(ds, xr.Dataset):
         raise TypeError("Please pass a model dataset!")
@@ -234,7 +233,8 @@ def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
                 elif sum(thicki[:ilay]) <= depth:
                     # hfb spans the cell partially
                     hydchr_frac = (depth - sum(thicki[:ilay])) / thicki[ilay]
-                    assert 0 <= hydchr_frac <= 1, "Something is wrong"
+                    if not 0 <= hydchr_frac <= 1:
+                        raise RuntimeError("HFB depth fraction is outside [0, 1]")
 
                     spd.append([cellid1, cellid2, hydchr * hydchr_frac])
                     break  # go to next cell
@@ -246,7 +246,8 @@ def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
             else:
                 # hfb spans the cell partially
                 hydchr_frac = (topi[ilay] - elevation) / thicki[ilay]
-                assert 0 <= hydchr_frac <= 1, "Something is wrong"
+                if not 0 <= hydchr_frac <= 1:
+                    raise RuntimeError("HFB elevation fraction is outside [0, 1]")
 
                 spd.append([cellid1, cellid2, hydchr * hydchr_frac])
                 break  # go to next cell

--- a/nlmod/gwf/hfb.py
+++ b/nlmod/gwf/hfb.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import xarray as xr
-from geopandas import GeoSeries
+from geopandas import GeoDataFrame, GeoSeries
 from shapely.geometry import Point, Polygon
 
 from ..dims.grid import (
@@ -22,12 +22,139 @@ from ..dims.layers import calculate_thickness, get_idomain
 
 logger = logging.getLogger(__name__)
 
+LINE_GEOM_TYPES = {"LineString", "MultiLineString"}
+
+
+def hfb_from_df(
+    df,
+    gwf,
+    ds,
+    hydchr="hydchr",
+    depth="depth",
+    elevation="elevation",
+    pname="hfb",
+    **kwargs,
+):
+    """Add a Horizontal Flow Barrier (HFB) package from line features.
+
+    Parameters
+    ----------
+    df : geopandas.GeoDataFrame
+        GeoDataFrame with LineString or MultiLineString features.
+    gwf : flopy.mf6.ModflowGwf
+        Groundwater flow model to add the HFB package to.
+    ds : xr.Dataset
+        Dataset with model data. Used for grid intersection, active cells, and layer
+        placement.
+    hydchr : str or float, optional
+        Column in ``df`` with the hydraulic characteristic, or a single value applied
+        to every feature. The default is "hydchr".
+    depth : str or float, optional
+        Column in ``df`` with the barrier depth below model top, or a single value
+        applied to every feature. Exactly one of ``depth`` or ``elevation`` must be set
+        per feature. The default is "depth".
+    elevation : str or float, optional
+        Column in ``df`` with the barrier bottom elevation, or a single value applied
+        to every feature. Exactly one of ``depth`` or ``elevation`` must be set per
+        feature. The default is "elevation".
+    pname : str, optional
+        Package name. The default is "hfb".
+    **kwargs : dict
+        Keyword arguments are passed to ``flopy.mf6.ModflowGwfhfb``.
+
+    Returns
+    -------
+    hfb : flopy.mf6.ModflowGwfhfb or None
+        HFB package. Returns None when no stress-period data are generated.
+    """
+    logger.info("creating mf6 HFB from dataframe")
+
+    if not isinstance(df, GeoDataFrame):
+        raise TypeError("df must be a geopandas GeoDataFrame")
+
+    if df.empty:
+        logger.warning("no hfb pkg added")
+        return None
+
+    unsupported = set(df.geometry.geom_type.dropna().unique()) - LINE_GEOM_TYPES
+    if unsupported:
+        raise ValueError(
+            "hfb_from_df supports only LineString and MultiLineString geometries; "
+            f"found {sorted(unsupported)}"
+        )
+
+    spd = []
+    for row_number, (index, row) in enumerate(df.iterrows()):
+        hydchr_value = _get_optional_hfb_value(row, hydchr, "hydchr", index)
+        if hydchr_value is None:
+            raise ValueError(f"hydchr must be set for HFB feature at index {index!r}")
+        if hydchr_value <= 0:
+            raise ValueError(
+                f"hydchr must be positive for HFB feature at index {index!r}"
+            )
+
+        depth_value = _get_optional_hfb_value(row, depth, "depth", index)
+        elevation_value = _get_optional_hfb_value(row, elevation, "elevation", index)
+        if (depth_value is None) == (elevation_value is None):
+            raise ValueError(
+                "Exactly one of depth or elevation must be set for HFB feature "
+                f"at index {index!r}"
+            )
+
+        feature = df.iloc[[row_number]]
+        if depth_value is not None:
+            spd += get_hfb_spd(ds, feature, hydchr=hydchr_value, depth=depth_value)
+        else:
+            spd += get_hfb_spd(
+                ds, feature, hydchr=hydchr_value, elevation=elevation_value
+            )
+
+    spd = _clean_hfb_spd(spd)
+    if len(spd) == 0:
+        logger.warning("no hfb pkg added")
+        return None
+
+    maxhfb = kwargs.pop("maxhfb", len(spd))
+    return flopy.mf6.ModflowGwfhfb(
+        gwf,
+        stress_period_data={0: spd},
+        maxhfb=maxhfb,
+        pname=pname,
+        **kwargs,
+    )
+
+
+def _get_optional_hfb_value(row, value_or_column, name, index):
+    if value_or_column is None:
+        return None
+    if isinstance(value_or_column, str):
+        if value_or_column not in row.index:
+            raise KeyError(
+                f"Column {value_or_column!r} not found for {name} of HFB feature "
+                f"at index {index!r}"
+            )
+        value = row[value_or_column]
+    else:
+        value = value_or_column
+    if pd.isna(value):
+        return None
+    return float(value)
+
+
+def _clean_hfb_spd(spd):
+    return [
+        [cellid1, cellid2, hydchr_float]
+        for cellid1, cellid2, hydchr in spd
+        if (hydchr_float := float(hydchr)) > 0
+    ]
+
 
 def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
-    """Generate a stress period data for horizontal flow barrier between two cell nodes,
-    with several limitations. The stress period data can be used directly in the HFB
-    package of flopy. The hfb is placed at the cell interface; it follows the sides of
-    the cells.
+    """Generate HFB stress period data between two cell nodes.
+
+    The function has several limitations. The stress period data can be used directly
+    in the HFB package of flopy. The hfb is placed at the cell interface; it follows
+    the sides of the cells.
 
     The estimation of the cross-sectional area at the interface is pretty crude, as the
     thickness at the cell interface is just the average of the thicknesses of the two
@@ -54,9 +181,9 @@ def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
     spd : List of Tuple
         Stress period data used to configure the hfb package of Flopy.
     """
-    assert (
-        sum([depth is None, elevation is None]) == 1
-    ), "Use either depth or elevation argument"
+    assert sum([depth is None, elevation is None]) == 1, (
+        "Use either depth or elevation argument"
+    )
 
     if not isinstance(ds, xr.Dataset):
         raise TypeError("Please pass a model dataset!")
@@ -76,8 +203,10 @@ def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
             thicki = (thick[:, icell2d1] + thick[:, icell2d2]) / 2
             topi = (tops[:, icell2d1] + tops[:, icell2d2]) / 2
         else:
-            thicki = (thick[:, *icell2d1] + thick[:, *icell2d2]) / 2
-            topi = (tops[*icell2d1] + tops[*icell2d2]) / 2
+            cell_index1 = (slice(None), *icell2d1)
+            cell_index2 = (slice(None), *icell2d2)
+            thicki = (thick[cell_index1] + thick[cell_index2]) / 2
+            topi = (tops[cell_index1] + tops[cell_index2]) / 2
 
         for ilay in range(ds.sizes["layer"]):
             cellid1 = (ilay,) + (
@@ -123,9 +252,10 @@ def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
 
 
 def line2hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
+    """Snap line to grid and return HFB cell pairs."""
     warnings.warn(
-        "The function 'line2hfb' is deprecated and will be removed in a future version. "
-        "Please use 'line_to_hfb' instead.",
+        "The function 'line2hfb' is deprecated and will be removed in a future "
+        "version. Please use 'line_to_hfb' instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -278,9 +408,12 @@ def line_to_hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
     # hfb_seg_unique, uidx = np.unique(hfb_seg[:, 1:], return_index=True, axis=0)
     # ucids = hfb_seg[uidx, 0]
     # try:
-    #     endpoint_cellid = mgrid.intersect(get_coordinates(gdf.geometry.union_all()[-1]))
+    #     endpoint_cellid = mgrid.intersect(
+    #         get_coordinates(gdf.geometry.union_all()[-1])
+    #     )
     # except Exception:  # e.g. point is on our outside model boundary
-    #     endpoint_cellid = ucids[-1]  # pick last cellid (this might not be the endpoint)
+    #     # Pick last cellid, which might not be the endpoint.
+    #     endpoint_cellid = ucids[-1]
     # n_segments_endpoint_cell = 0
 
     # Get rid of disconnected (or 'open') segments
@@ -395,7 +528,7 @@ def line_to_hfb_buffer(gdf, ds, buffer_distance=None, gi=None):
     mgrid = modelgrid_from_ds(ds)
     hfb_seg = []
     if is_structured(ds):
-        for cid in zip(*cellids):
+        for cid in zip(*cellids, strict=False):
             neighbors = mgrid.neighbors(0, *cid)
             for n in neighbors:
                 if da.values[n[1:]] == -1:

--- a/nlmod/gwf/hfb.py
+++ b/nlmod/gwf/hfb.py
@@ -276,17 +276,24 @@ def line2hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
     """Snap line to grid and return HFB cell pairs."""
     warnings.warn(
         "The function 'line2hfb' is deprecated and will be removed in a future "
-        "version. Please use 'line_to_hfb' instead.",
+        "version. Please use 'flopy.utils.make_hfb_array' for cell-pair routing, "
+        "or 'get_hfb_spd'/'hfb_from_df' for nlmod HFB stress-period data.",
         DeprecationWarning,
         stacklevel=2,
     )
-    return line_to_hfb(
-        gdf=gdf,
-        ds=ds,
-        gwf=gwf,
-        prevent_rings=prevent_rings,
-        plot=plot,
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The function 'line_to_hfb' is deprecated.*",
+            category=DeprecationWarning,
+        )
+        return line_to_hfb(
+            gdf=gdf,
+            ds=ds,
+            gwf=gwf,
+            prevent_rings=prevent_rings,
+            plot=plot,
+        )
 
 
 def line_to_hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
@@ -316,6 +323,14 @@ def line_to_hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
     cellids : 2d list of ints
         a list with pairs of cells that have a hfb between them.
     """
+    warnings.warn(
+        "The function 'line_to_hfb' is deprecated and will be removed in a future "
+        "version. Please use 'flopy.utils.make_hfb_array' for cell-pair routing, "
+        "or 'get_hfb_spd'/'hfb_from_df' for nlmod HFB stress-period data.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     # for the idea, see:
     # https://gis.stackexchange.com/questions/188755/how-to-snap-a-road-network-to-a-hexagonal-grid-in-qgis
 
@@ -500,6 +515,14 @@ def line_to_hfb_buffer(gdf, ds, buffer_distance=None, gi=None):
     hfb_seg : list of tuples
         List of tuples with cellids that share a face.
     """
+    warnings.warn(
+        "The function 'line_to_hfb_buffer' is deprecated and will be removed in a "
+        "future version. Please use 'flopy.utils.make_hfb_array' for cell-pair "
+        "routing, or 'get_hfb_spd'/'hfb_from_df' for nlmod HFB stress-period data.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if buffer_distance is None:
         # buffer distance ~ 1.5 * max cell size
         buffer_distance = 1.5 * np.max(

--- a/nlmod/gwf/hfb.py
+++ b/nlmod/gwf/hfb.py
@@ -6,8 +6,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import xarray as xr
+from flopy.utils import make_hfb_array
 from geopandas import GeoDataFrame, GeoSeries
-from shapely.geometry import Point, Polygon
+from shapely.geometry import MultiLineString, Point, Polygon
 
 from ..dims.grid import (
     gdf_to_da,
@@ -153,6 +154,36 @@ def _clean_hfb_spd(spd):
     ]
 
 
+def _iter_linestring_geometries(linestrings):
+    if isinstance(linestrings, GeoDataFrame):
+        geometries = linestrings.geometry
+    elif isinstance(linestrings, GeoSeries):
+        geometries = linestrings
+    else:
+        geometries = [linestrings]
+
+    for geometry in geometries:
+        if geometry is None:
+            continue
+        if isinstance(geometry, MultiLineString):
+            yield from geometry.geoms
+        else:
+            yield geometry
+
+
+def _get_hfb_cells_from_linestrings(ds, linestrings, idomain):
+    modelgrid = modelgrid_from_ds(ds, idomain=idomain.values)
+    cells = []
+    for geometry in _iter_linestring_geometries(linestrings):
+        cells.extend(
+            [
+                (tuple(int(i) for i in row.cellid1), tuple(int(i) for i in row.cellid2))
+                for row in make_hfb_array(modelgrid, geometry)
+            ]
+        )
+    return cells
+
+
 def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
     """Generate HFB stress period data between two cell nodes.
 
@@ -191,66 +222,52 @@ def get_hfb_spd(ds, linestrings, hydchr, depth=None, elevation=None):
     if not isinstance(ds, xr.Dataset):
         raise TypeError("Please pass a model dataset!")
 
-    thick = calculate_thickness(ds)
+    thick = calculate_thickness(ds).values
     idomain = get_idomain(ds)
     tops = np.concatenate((ds["top"].values[np.newaxis], ds["botm"].values))
-    cells = line_to_hfb(linestrings, ds)
-
-    # drop cells on the edge of the model
-    cells = [x for x in cells if len(x) > 1]
+    cells = _get_hfb_cells_from_linestrings(ds, linestrings, idomain)
 
     spd = []
-    for icell2d1, icell2d2 in cells:
+    for cellid1, cellid2 in cells:
+        if idomain.values[cellid1] <= 0:
+            continue
+
+        if idomain.values[cellid2] <= 0:
+            continue
+
+        ilay = cellid1[0]
         # TODO: Improve assumption of the thickness between the cells.
-        if isinstance(icell2d1, (int, np.integer)):
-            thicki = (thick[:, icell2d1] + thick[:, icell2d2]) / 2
-            topi = (tops[:, icell2d1] + tops[:, icell2d2]) / 2
-        else:
-            cell_index1 = (slice(None), *icell2d1)
-            cell_index2 = (slice(None), *icell2d2)
-            thicki = (thick[cell_index1] + thick[cell_index2]) / 2
-            topi = (tops[cell_index1] + tops[cell_index2]) / 2
+        cell_index1 = (slice(None), *cellid1[1:])
+        cell_index2 = (slice(None), *cellid2[1:])
+        thicki = (thick[cell_index1] + thick[cell_index2]) / 2
+        topi = (tops[cell_index1] + tops[cell_index2]) / 2
 
-        for ilay in range(ds.sizes["layer"]):
-            cellid1 = (ilay,) + (
-                icell2d1 if isinstance(icell2d1, tuple) else (icell2d1,)
-            )
-            cellid2 = (ilay,) + (
-                icell2d2 if isinstance(icell2d2, tuple) else (icell2d2,)
-            )
-
-            if idomain.values[cellid1] <= 0:
-                continue
-
-            if idomain.values[cellid2] <= 0:
-                continue
-
-            if depth is not None:
-                if sum(thicki[: ilay + 1]) <= depth:
-                    # hfb spans the entire cell
-                    spd.append([cellid1, cellid2, hydchr])
-
-                elif sum(thicki[:ilay]) <= depth:
-                    # hfb spans the cell partially
-                    hydchr_frac = (depth - sum(thicki[:ilay])) / thicki[ilay]
-                    if not 0 <= hydchr_frac <= 1:
-                        raise RuntimeError("HFB depth fraction is outside [0, 1]")
-
-                    spd.append([cellid1, cellid2, hydchr * hydchr_frac])
-                    break  # go to next cell
-
-            elif topi[ilay + 1] >= elevation:
+        if depth is not None:
+            layer_top_depth = sum(thicki[:ilay])
+            layer_bottom_depth = sum(thicki[: ilay + 1])
+            if layer_bottom_depth <= depth:
                 # hfb spans the entire cell
                 spd.append([cellid1, cellid2, hydchr])
 
-            else:
+            elif layer_top_depth <= depth:
                 # hfb spans the cell partially
-                hydchr_frac = (topi[ilay] - elevation) / thicki[ilay]
+                hydchr_frac = (depth - layer_top_depth) / thicki[ilay]
                 if not 0 <= hydchr_frac <= 1:
-                    raise RuntimeError("HFB elevation fraction is outside [0, 1]")
+                    raise RuntimeError("HFB depth fraction is outside [0, 1]")
 
                 spd.append([cellid1, cellid2, hydchr * hydchr_frac])
-                break  # go to next cell
+
+        elif topi[ilay + 1] >= elevation:
+            # hfb spans the entire cell
+            spd.append([cellid1, cellid2, hydchr])
+
+        elif topi[ilay] >= elevation:
+            # hfb spans the cell partially
+            hydchr_frac = (topi[ilay] - elevation) / thicki[ilay]
+            if not 0 <= hydchr_frac <= 1:
+                raise RuntimeError("HFB elevation fraction is outside [0, 1]")
+
+            spd.append([cellid1, cellid2, hydchr * hydchr_frac])
 
     return spd
 
@@ -409,18 +426,6 @@ def line_to_hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
 
     # get unique segments
     hfb_seg_unique = np.unique(hfb_seg[:, 1:], axis=0)
-    # NOTE: see next note describing the idea behind this code. Leaving here for future
-    # review.
-    # hfb_seg_unique, uidx = np.unique(hfb_seg[:, 1:], return_index=True, axis=0)
-    # ucids = hfb_seg[uidx, 0]
-    # try:
-    #     endpoint_cellid = mgrid.intersect(
-    #         get_coordinates(gdf.geometry.union_all()[-1])
-    #     )
-    # except Exception:  # e.g. point is on our outside model boundary
-    #     # Pick last cellid, which might not be the endpoint.
-    #     endpoint_cellid = ucids[-1]
-    # n_segments_endpoint_cell = 0
 
     # Get rid of disconnected (or 'open') segments
     # Let's remove disconnected/open segments
@@ -433,18 +438,6 @@ def line_to_hfb(gdf, ds=None, gwf=None, prevent_rings=True, plot=False):
             segments_per_iv[segment[1]] == 1 and segments_per_iv[segment[0]] >= 3
         ):
             mask[i] = False
-        # NOTE: the code below can be used to avoid dropping all segments in the
-        # final cell, leaving it here for review in the future.
-        #     if ensure_endpoint_segment:
-        #         # keep at least one segment in final cell
-        #         if ucids[i] == endpoint_cellid and n_segments_endpoint_cell == 0:
-        #             continue
-        #         else:
-        #             mask[i] = False
-        #     else:
-        #         mask[i] = False
-        # elif ensure_endpoint_segment and ucids[i] == endpoint_cellid:
-        #     n_segments_endpoint_cell += 1
     hfb_seg_unique = hfb_seg_unique[mask]
 
     if plot:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "flopy>=3.10.0",
+    "flopy @ git+https://github.com/modflowpy/flopy.git@7c717126d81259eb9ae6196f420e56aa56744a86",
     "xarray>=0.16.1",
     "netcdf4>=1.7.2",
     "rasterio>=1.1.0",
@@ -133,4 +133,3 @@ pydocstyle.convention = "numpy"
 [tool.pytest.ini_options]
 addopts = "--strict-markers --durations=0 --cov-report xml:coverage.xml --cov nlmod -v"
 markers = ["notebooks: run notebooks", "slow: slow tests", "skip: skip tests"]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "flopy @ git+https://github.com/modflowpy/flopy.git@7c717126d81259eb9ae6196f420e56aa56744a86",
+    "flopy @ git+https://github.com/modflowpy/flopy.git@3405517c7d2fed2667722fe8dc07b0d2af269fbe",
     "xarray>=0.16.1",
     "netcdf4>=1.7.2",
     "rasterio>=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "flopy @ git+https://github.com/modflowpy/flopy.git@3405517c7d2fed2667722fe8dc07b0d2af269fbe",
+    "flopy @ git+https://github.com/modflowpy/flopy.git@develop", # HFB utility from flopy#2745, to be released in flopy>3.10.0
     "xarray>=0.16.1",
     "netcdf4>=1.7.2",
     "rasterio>=1.1.0",

--- a/tests/test_023_hfb.py
+++ b/tests/test_023_hfb.py
@@ -8,19 +8,92 @@ import flopy
 import geopandas as gpd
 import pandas as pd
 import util
+from flopy.utils import make_hfb_array
 from shapely.geometry import LineString, MultiLineString, Point, Polygon
 
 import nlmod
+from nlmod.dims.grid import modelgrid_from_ds
+from nlmod.dims.layers import get_idomain
+
+
+def _normalize_spd(spd):
+    return [
+        (tuple(int(i) for i in cellid1), tuple(int(i) for i in cellid2), float(hydchr))
+        for cellid1, cellid2, hydchr in spd
+    ]
+
+
+def _structured_diagonal_expected_spd(hydchr=1 / 100.0):
+    expected_spd = []
+    for ilay, layer_hydchr in ((0, hydchr), (1, hydchr), (2, hydchr * 0.5)):
+        for idx in range(9):
+            expected_spd.append(((ilay, idx, idx), (ilay, idx + 1, idx), layer_hydchr))
+            expected_spd.append(
+                ((ilay, idx + 1, idx + 1), (ilay, idx + 1, idx), layer_hydchr)
+            )
+    return expected_spd
+
+
+def _flopy_pair_set(ds, geometry, layer=0):
+    modelgrid = modelgrid_from_ds(ds, idomain=get_idomain(ds).values)
+    return {
+        frozenset(
+            (
+                tuple(int(i) for i in row.cellid1),
+                tuple(int(i) for i in row.cellid2),
+            )
+        )
+        for row in make_hfb_array(modelgrid, geometry)
+        if int(row.cellid1[0]) == layer
+    }
+
+
+def _flopy_depth5_top_layer_spd(ds, geometries, hydchr):
+    if not isinstance(geometries, (list, tuple)):
+        geometries = [geometries]
+    modelgrid = modelgrid_from_ds(ds, idomain=get_idomain(ds).values)
+    expected_spd = []
+    for geometry in geometries:
+        for row in make_hfb_array(modelgrid, geometry):
+            cellid1 = tuple(int(i) for i in row.cellid1)
+            cellid2 = tuple(int(i) for i in row.cellid2)
+            if cellid1[0] == 0:
+                expected_spd.append((cellid1, cellid2, hydchr * 0.5))
+    return expected_spd
+
+
+def test_flopy_make_hfb_array_available():
+    assert callable(make_hfb_array)
+
+
+def test_get_hfb_spd_uses_flopy_make_hfb_array(monkeypatch):
+    ds = util.get_ds_structured()
+    gdf = gpd.GeoDataFrame({"geometry": [LineString([(0, 1000), (1000, 0)])]})
+    calls = []
+    original_make_hfb_array = nlmod.gwf.hfb.make_hfb_array
+
+    def spy_make_hfb_array(modelgrid, geometry):
+        calls.append((modelgrid, geometry))
+        return original_make_hfb_array(modelgrid, geometry)
+
+    monkeypatch.setattr(nlmod.gwf.hfb, "make_hfb_array", spy_make_hfb_array)
+
+    nlmod.gwf.hfb.get_hfb_spd(ds, gdf, hydchr=1 / 100.0, depth=5.0)
+
+    assert len(calls) == 1
 
 
 def test_get_hfb_spd_vertex():
-    # this test also tests line_to_hfb
     ds = util.get_ds_vertex()
     ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
     gwf = util.get_gwf(ds)
-    coords = [(0, 1000), (1000, 0)]
-    gdf = gpd.GeoDataFrame({"geometry": [LineString(coords)]})
+    geometry = LineString([(0, 1000), (1000, 0)])
+    gdf = gpd.GeoDataFrame({"geometry": [geometry]})
     spd = nlmod.gwf.hfb.get_hfb_spd(ds, gdf, hydchr=1 / 100.0, depth=5.0)
+    assert {
+        frozenset((cellid1, cellid2)) for cellid1, cellid2, _ in _normalize_spd(spd)
+    } == _flopy_pair_set(ds, geometry)
+    assert {hydchr for _, _, hydchr in _normalize_spd(spd)} == {0.005}
     hfb = flopy.mf6.ModflowGwfhfb(gwf, stress_period_data={0: spd})
     # also test the plot method
     ax = gdf.plot()
@@ -28,17 +101,56 @@ def test_get_hfb_spd_vertex():
 
 
 def test_get_hfb_spd_structured():
-    # this test also tests line_to_hfb
     ds = util.get_ds_structured()
     ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
     gwf = util.get_gwf(ds)
     coords = [(0, 1000), (1000, 0)]
     gdf = gpd.GeoDataFrame({"geometry": [LineString(coords)]})
-    spd = nlmod.gwf.hfb.get_hfb_spd(ds, gdf, hydchr=1 / 100.0, depth=5.0)
+    spd = nlmod.gwf.hfb.get_hfb_spd(ds, gdf, hydchr=1 / 100.0, depth=25.0)
+    assert _normalize_spd(spd) == _structured_diagonal_expected_spd()
+    elevation_spd = nlmod.gwf.hfb.get_hfb_spd(
+        ds, gdf, hydchr=1 / 100.0, elevation=-25.0
+    )
+    assert _normalize_spd(elevation_spd) == _structured_diagonal_expected_spd()
     hfb = flopy.mf6.ModflowGwfhfb(gwf, stress_period_data={0: spd})
     # also test the plot method
     ax = gdf.plot()
     nlmod.gwf.hfb.plot_hfb(hfb, gwf, ax=ax)
+
+
+def test_get_hfb_spd_skips_inactive_and_passthrough_cells():
+    ds = util.get_ds_structured()
+    ds["botm"].values[1] = ds["botm"].values[0]
+    active_domain = ds["top"] == ds["top"]
+    active_domain.values[0, 0] = False
+    ds["active_domain"] = active_domain
+    idomain = get_idomain(ds)
+    geometry = LineString([(0, 1000), (1000, 0)])
+    gdf = gpd.GeoDataFrame({"geometry": [geometry]})
+
+    spd = _normalize_spd(
+        nlmod.gwf.hfb.get_hfb_spd(ds, gdf, hydchr=1 / 100.0, depth=25.0)
+    )
+    expected_spd = []
+    for ilay, layer_hydchr in ((0, 1 / 100.0), (2, 0.0075)):
+        for idx in range(9):
+            expected_spd.append(((ilay, idx, idx), (ilay, idx + 1, idx), layer_hydchr))
+            expected_spd.append(
+                ((ilay, idx + 1, idx + 1), (ilay, idx + 1, idx), layer_hydchr)
+            )
+    expected_spd = [
+        row for row in expected_spd if row[0][1:] != (0, 0) and row[1][1:] != (0, 0)
+    ]
+
+    assert spd == expected_spd
+    assert all(
+        idomain.values[cellid1] > 0 and idomain.values[cellid2] > 0
+        for cellid1, cellid2, _ in spd
+    )
+    assert all(cellid1[0] != 1 and cellid2[0] != 1 for cellid1, cellid2, _ in spd)
+    assert all(
+        cellid1[1:] != (0, 0) and cellid2[1:] != (0, 0) for cellid1, cellid2, _ in spd
+    )
 
 
 def test_hfb_from_df_vertex():
@@ -294,19 +406,12 @@ def test_hfb_from_df_accepts_multilinestring():
         elevation=None,
     )
 
-    expected_spd = nlmod.gwf.hfb.get_hfb_spd(
-        ds,
-        gdf,
-        hydchr=1 / 100.0,
-        depth=5.0,
+    expected_spd = _flopy_depth5_top_layer_spd(
+        ds, list(gdf.geometry.iloc[0].geoms), 1 / 100.0
     )
-    expected_spd = [
-        [cellid1, cellid2, float(hydchr)]
-        for cellid1, cellid2, hydchr in expected_spd
-        if float(hydchr) > 0
-    ]
     actual_spd = [
-        [row[0], row[1], float(row[2])] for row in hfb.stress_period_data.data[0]
+        (tuple(row[0]), tuple(row[1]), float(row[2]))
+        for row in hfb.stress_period_data.data[0]
     ]
     assert actual_spd == expected_spd
 

--- a/tests/test_023_hfb.py
+++ b/tests/test_023_hfb.py
@@ -54,7 +54,7 @@ def test_hfb_from_df_vertex():
                 LineString([(0, 1000), (1000, 0)]),
                 LineString([(100, 1000), (1000, 100)]),
             ],
-        }
+        },
     )
 
     hfb = nlmod.gwf.hfb.hfb_from_df(gdf, gwf, ds, pname="hfb_test")
@@ -97,7 +97,7 @@ def test_hfb_from_df_requires_depth_or_elevation():
             "depth": [None],
             "elevation": [None],
             "geometry": [LineString([(0, 1000), (1000, 0)])],
-        }
+        },
     )
 
     with pytest.raises(ValueError, match="Exactly one"):
@@ -119,7 +119,7 @@ def test_hfb_from_df_rejects_nonpositive_hydchr(hydchr):
             "hydchr": [hydchr],
             "depth": [5.0],
             "geometry": [LineString([(0, 1000), (1000, 0)])],
-        }
+        },
     )
 
     with pytest.raises(ValueError, match="hydchr must be positive"):
@@ -135,7 +135,7 @@ def test_hfb_from_df_returns_none_when_all_hydchr_rows_are_zero():
             "hydchr": [1 / 100.0],
             "depth": [0.0],
             "geometry": [LineString([(0, 1000), (1000, 0)])],
-        }
+        },
     )
 
     assert nlmod.gwf.hfb.hfb_from_df(gdf, gwf, ds, elevation=None) is None
@@ -150,7 +150,7 @@ def test_hfb_from_df_rejects_non_line_geometries():
             "hydchr": [1 / 100.0],
             "depth": [5.0],
             "geometry": [Point(0, 1000)],
-        }
+        },
     )
 
     with pytest.raises(ValueError, match="LineString"):
@@ -198,8 +198,8 @@ def test_hfb_from_df_scalar_values_apply_to_all_features():
             "geometry": [
                 LineString([(0, 1000), (1000, 0)]),
                 LineString([(100, 1000), (1000, 100)]),
-            ]
-        }
+            ],
+        },
     )
 
     hfb = nlmod.gwf.hfb.hfb_from_df(
@@ -239,7 +239,7 @@ def test_hfb_from_df_accepts_custom_column_names():
             "resistance_inverse": [1 / 100.0],
             "barrier_depth": [5.0],
             "geometry": [LineString([(0, 1000), (1000, 0)])],
-        }
+        },
     )
 
     hfb = nlmod.gwf.hfb.hfb_from_df(
@@ -279,10 +279,10 @@ def test_hfb_from_df_accepts_multilinestring():
                     [
                         [(0, 1000), (500, 500)],
                         [(500, 500), (1000, 0)],
-                    ]
-                )
-            ]
-        }
+                    ],
+                ),
+            ],
+        },
     )
 
     hfb = nlmod.gwf.hfb.hfb_from_df(
@@ -379,7 +379,7 @@ def test_line_to_hfb_buffer_structured():
                 LineString([(100, 1000), (225.0, 425.1)]),
                 LineString([(225.0, 425.1), (225.0, 0)]),
             ],
-        }
+        },
     )
     cellids = nlmod.gwf.hfb.line_to_hfb_buffer(gdf, ds)
     # also test the plot method
@@ -400,7 +400,7 @@ def test_line_to_hfb_buffer_vertex():
                 LineString([(100, 1000), (225.0, 425.1)]),
                 LineString([(225.0, 425.1), (225.0, 0)]),
             ],
-        }
+        },
     )
     cellids = nlmod.gwf.hfb.line_to_hfb_buffer(gdf, ds)
     # also test the plot method

--- a/tests/test_023_hfb.py
+++ b/tests/test_023_hfb.py
@@ -1,12 +1,14 @@
 # ruff: noqa: D103
 import matplotlib
+import pytest
 
 matplotlib.use("Agg")
 
 import flopy
 import geopandas as gpd
+import pandas as pd
 import util
-from shapely.geometry import LineString, Polygon
+from shapely.geometry import LineString, MultiLineString, Point, Polygon
 
 import nlmod
 
@@ -37,6 +39,308 @@ def test_get_hfb_spd_structured():
     # also test the plot method
     ax = gdf.plot()
     nlmod.gwf.hfb.plot_hfb(hfb, gwf, ax=ax)
+
+
+def test_hfb_from_df_vertex():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame(
+        {
+            "hydchr": [1 / 100.0, 1 / 200.0],
+            "depth": [5.0, None],
+            "elevation": [None, -2.0],
+            "geometry": [
+                LineString([(0, 1000), (1000, 0)]),
+                LineString([(100, 1000), (1000, 100)]),
+            ],
+        }
+    )
+
+    hfb = nlmod.gwf.hfb.hfb_from_df(gdf, gwf, ds, pname="hfb_test")
+
+    assert hfb.package_name == "hfb_test"
+    expected_spd = []
+    for row_number, row in enumerate(gdf.itertuples()):
+        if pd.notna(row.depth):
+            expected_spd += nlmod.gwf.hfb.get_hfb_spd(
+                ds,
+                gdf.iloc[[row_number]],
+                hydchr=row.hydchr,
+                depth=row.depth,
+            )
+        else:
+            expected_spd += nlmod.gwf.hfb.get_hfb_spd(
+                ds,
+                gdf.iloc[[row_number]],
+                hydchr=row.hydchr,
+                elevation=row.elevation,
+            )
+    expected_spd = [
+        [cellid1, cellid2, float(hydchr)]
+        for cellid1, cellid2, hydchr in expected_spd
+        if float(hydchr) > 0
+    ]
+    actual_spd = [
+        [row[0], row[1], float(row[2])] for row in hfb.stress_period_data.data[0]
+    ]
+    assert actual_spd == expected_spd
+
+
+def test_hfb_from_df_requires_depth_or_elevation():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame(
+        {
+            "hydchr": [1 / 100.0],
+            "depth": [None],
+            "elevation": [None],
+            "geometry": [LineString([(0, 1000), (1000, 0)])],
+        }
+    )
+
+    with pytest.raises(ValueError, match="Exactly one"):
+        nlmod.gwf.hfb.hfb_from_df(gdf, gwf, ds)
+
+    gdf.loc[0, "depth"] = 5.0
+    gdf.loc[0, "elevation"] = -2.0
+    with pytest.raises(ValueError, match="Exactly one"):
+        nlmod.gwf.hfb.hfb_from_df(gdf, gwf, ds)
+
+
+@pytest.mark.parametrize("hydchr", [0.0, -0.01])
+def test_hfb_from_df_rejects_nonpositive_hydchr(hydchr):
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame(
+        {
+            "hydchr": [hydchr],
+            "depth": [5.0],
+            "geometry": [LineString([(0, 1000), (1000, 0)])],
+        }
+    )
+
+    with pytest.raises(ValueError, match="hydchr must be positive"):
+        nlmod.gwf.hfb.hfb_from_df(gdf, gwf, ds, elevation=None)
+
+
+def test_hfb_from_df_returns_none_when_all_hydchr_rows_are_zero():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame(
+        {
+            "hydchr": [1 / 100.0],
+            "depth": [0.0],
+            "geometry": [LineString([(0, 1000), (1000, 0)])],
+        }
+    )
+
+    assert nlmod.gwf.hfb.hfb_from_df(gdf, gwf, ds, elevation=None) is None
+
+
+def test_hfb_from_df_rejects_non_line_geometries():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame(
+        {
+            "hydchr": [1 / 100.0],
+            "depth": [5.0],
+            "geometry": [Point(0, 1000)],
+        }
+    )
+
+    with pytest.raises(ValueError, match="LineString"):
+        nlmod.gwf.hfb.hfb_from_df(gdf, gwf, ds, elevation=None)
+
+
+def test_hfb_from_df_accepts_scalar_values():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame({"geometry": [LineString([(0, 1000), (1000, 0)])]})
+
+    hfb = nlmod.gwf.hfb.hfb_from_df(
+        gdf,
+        gwf,
+        ds,
+        hydchr=1 / 100.0,
+        depth=5.0,
+        elevation=None,
+    )
+
+    expected_spd = nlmod.gwf.hfb.get_hfb_spd(
+        ds,
+        gdf,
+        hydchr=1 / 100.0,
+        depth=5.0,
+    )
+    expected_spd = [
+        [cellid1, cellid2, float(hydchr)]
+        for cellid1, cellid2, hydchr in expected_spd
+        if float(hydchr) > 0
+    ]
+    actual_spd = [
+        [row[0], row[1], float(row[2])] for row in hfb.stress_period_data.data[0]
+    ]
+    assert actual_spd == expected_spd
+
+
+def test_hfb_from_df_scalar_values_apply_to_all_features():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame(
+        {
+            "geometry": [
+                LineString([(0, 1000), (1000, 0)]),
+                LineString([(100, 1000), (1000, 100)]),
+            ]
+        }
+    )
+
+    hfb = nlmod.gwf.hfb.hfb_from_df(
+        gdf,
+        gwf,
+        ds,
+        hydchr=1 / 100.0,
+        depth=5.0,
+        elevation=None,
+    )
+
+    expected_spd = []
+    for row_number in range(len(gdf)):
+        expected_spd += nlmod.gwf.hfb.get_hfb_spd(
+            ds,
+            gdf.iloc[[row_number]],
+            hydchr=1 / 100.0,
+            depth=5.0,
+        )
+    expected_spd = [
+        [cellid1, cellid2, float(hydchr)]
+        for cellid1, cellid2, hydchr in expected_spd
+        if float(hydchr) > 0
+    ]
+    actual_spd = [
+        [row[0], row[1], float(row[2])] for row in hfb.stress_period_data.data[0]
+    ]
+    assert actual_spd == expected_spd
+
+
+def test_hfb_from_df_accepts_custom_column_names():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame(
+        {
+            "resistance_inverse": [1 / 100.0],
+            "barrier_depth": [5.0],
+            "geometry": [LineString([(0, 1000), (1000, 0)])],
+        }
+    )
+
+    hfb = nlmod.gwf.hfb.hfb_from_df(
+        gdf,
+        gwf,
+        ds,
+        hydchr="resistance_inverse",
+        depth="barrier_depth",
+        elevation=None,
+    )
+
+    expected_spd = nlmod.gwf.hfb.get_hfb_spd(
+        ds,
+        gdf,
+        hydchr=1 / 100.0,
+        depth=5.0,
+    )
+    expected_spd = [
+        [cellid1, cellid2, float(hydchr)]
+        for cellid1, cellid2, hydchr in expected_spd
+        if float(hydchr) > 0
+    ]
+    actual_spd = [
+        [row[0], row[1], float(row[2])] for row in hfb.stress_period_data.data[0]
+    ]
+    assert actual_spd == expected_spd
+
+
+def test_hfb_from_df_accepts_multilinestring():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame(
+        {
+            "geometry": [
+                MultiLineString(
+                    [
+                        [(0, 1000), (500, 500)],
+                        [(500, 500), (1000, 0)],
+                    ]
+                )
+            ]
+        }
+    )
+
+    hfb = nlmod.gwf.hfb.hfb_from_df(
+        gdf,
+        gwf,
+        ds,
+        hydchr=1 / 100.0,
+        depth=5.0,
+        elevation=None,
+    )
+
+    expected_spd = nlmod.gwf.hfb.get_hfb_spd(
+        ds,
+        gdf,
+        hydchr=1 / 100.0,
+        depth=5.0,
+    )
+    expected_spd = [
+        [cellid1, cellid2, float(hydchr)]
+        for cellid1, cellid2, hydchr in expected_spd
+        if float(hydchr) > 0
+    ]
+    actual_spd = [
+        [row[0], row[1], float(row[2])] for row in hfb.stress_period_data.data[0]
+    ]
+    assert actual_spd == expected_spd
+
+
+def test_hfb_from_df_accepts_scalar_elevation():
+    ds = util.get_ds_vertex()
+    ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
+    gwf = util.get_gwf(ds)
+    gdf = gpd.GeoDataFrame({"geometry": [LineString([(0, 1000), (1000, 0)])]})
+
+    hfb = nlmod.gwf.hfb.hfb_from_df(
+        gdf,
+        gwf,
+        ds,
+        hydchr=1 / 200.0,
+        depth=None,
+        elevation=-2.0,
+    )
+
+    expected_spd = nlmod.gwf.hfb.get_hfb_spd(
+        ds,
+        gdf,
+        hydchr=1 / 200.0,
+        elevation=-2.0,
+    )
+    expected_spd = [
+        [cellid1, cellid2, float(hydchr)]
+        for cellid1, cellid2, hydchr in expected_spd
+        if float(hydchr) > 0
+    ]
+    actual_spd = [
+        [row[0], row[1], float(row[2])] for row in hfb.stress_period_data.data[0]
+    ]
+    assert actual_spd == expected_spd
 
 
 def test_polygon_to_hfb_vertex():

--- a/tests/test_023_hfb.py
+++ b/tests/test_023_hfb.py
@@ -472,8 +472,32 @@ def test_polygon_to_hfb_structured():
     nlmod.gwf.hfb.plot_hfb(hfb, gwf, ax=ax)
 
 
+def test_line_to_hfb_deprecated():
+    ds = util.get_ds_structured()
+    gdf = gpd.GeoDataFrame({"geometry": [LineString([(100, 1000), (225.0, 425.1)])]})
+
+    with pytest.warns(DeprecationWarning, match="line_to_hfb.*deprecated"):
+        cellids = nlmod.gwf.hfb.line_to_hfb(gdf, ds)
+
+    assert cellids
+
+
+def test_line2hfb_deprecated_without_duplicate_line_to_hfb_warning():
+    ds = util.get_ds_structured()
+    gdf = gpd.GeoDataFrame({"geometry": [LineString([(100, 1000), (225.0, 425.1)])]})
+
+    with pytest.warns(
+        DeprecationWarning, match="line2hfb.*deprecated"
+    ) as warning_records:
+        cellids = nlmod.gwf.hfb.line2hfb(gdf, ds)
+
+    messages = [str(record.message) for record in warning_records]
+    assert any("line2hfb" in message for message in messages)
+    assert not any("line_to_hfb" in message for message in messages)
+    assert cellids
+
+
 def test_line_to_hfb_buffer_structured():
-    # this test also tests line_to_hfb
     ds = util.get_ds_structured()
     ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
     gwf = util.get_gwf(ds)
@@ -486,7 +510,8 @@ def test_line_to_hfb_buffer_structured():
             ],
         },
     )
-    cellids = nlmod.gwf.hfb.line_to_hfb_buffer(gdf, ds)
+    with pytest.warns(DeprecationWarning, match="line_to_hfb_buffer.*deprecated"):
+        cellids = nlmod.gwf.hfb.line_to_hfb_buffer(gdf, ds)
     # also test the plot method
     ax = gdf.plot(column="name")
     gwf.modelgrid.plot(ax=ax)
@@ -494,7 +519,6 @@ def test_line_to_hfb_buffer_structured():
 
 
 def test_line_to_hfb_buffer_vertex():
-    # this test also tests line_to_hfb
     ds = util.get_ds_vertex()
     ds = nlmod.time.set_ds_time(ds, "2023", time="2024")
     gwf = util.get_gwf(ds)
@@ -507,7 +531,8 @@ def test_line_to_hfb_buffer_vertex():
             ],
         },
     )
-    cellids = nlmod.gwf.hfb.line_to_hfb_buffer(gdf, ds)
+    with pytest.warns(DeprecationWarning, match="line_to_hfb_buffer.*deprecated"):
+        cellids = nlmod.gwf.hfb.line_to_hfb_buffer(gdf, ds)
     # also test the plot method
     ax = gdf.plot(column="name")
     gwf.modelgrid.plot(ax=ax)


### PR DESCRIPTION
The full workflow from GeoDataFrame line features to a FloPy HFB package is implemented in nlmod, while delegating the horizontal line-to-cell routing to FloPy.

## Summary
- add `nlmod.gwf.hfb.hfb_from_df` to build MF6 HFB packages from line GeoDataFrames
- delegate HFB line routing to `flopy.utils.make_hfb_array` from modflowpy/flopy#2745
- keep nlmod-specific depth/elevation `hydchr` scaling and `idomain <= 0` filtering around the FloPy-generated cell pairs
- use FloPy `develop` until the HFB utility from flopy#2745 is available in a release (`flopy>3.10.0`)
- cover default columns, scalar values, custom columns, MultiLineString input, package naming, zero-SPD cleanup, FloPy routing, and inactive/pass-through filtering in HFB tests

## Validation
- `python -m py_compile nlmod\gwf\hfb.py`
- `python -m ruff format nlmod\gwf\hfb.py tests\test_023_hfb.py`
- `python -m ruff check --fix nlmod\gwf\hfb.py tests\test_023_hfb.py`
- `python -m pytest tests\test_023_hfb.py -v`
- `python -m prospector nlmod\gwf\hfb.py tests\test_023_hfb.py`
- `bandit -q -r nlmod\gwf\hfb.py`
- local availability check for `flopy.utils.make_hfb_array`