### PR TITLE
Aggregate lake pieces per cell in lake_from_gdf, like RIV/DRN celldata aggregation

### DIFF
--- a/nlmod/gwf/lake.py
+++ b/nlmod/gwf/lake.py
@@ -62,6 +62,11 @@ def lake_from_gdf(
             lakeno : with the number of the lake
             strt : with the starting head of the lake
             clake : with the bed resistance of the lake
+        A lake may have multiple rows (polygon pieces) per cellid, e.g. straight
+        from nlmod.grid.gdf_to_grid. Pieces are combined into one lake-GWF
+        connection per cell with an area-weighted bed resistance (see
+        _aggregate_connections_per_cell), like nlmod.gwf.surface_water.aggregate
+        already does for RIV/DRN celldata.
             optional columns are 'STATUS', 'STAGE', 'RAINFALL', 'EVAPORATION',
             'RUNOFF', 'INFLOW', 'WITHDRAWAL', 'AUXILIARY', 'RATE', 'INVERT',
             'WIDTH', 'SLOPE', 'ROUGH'. These columns should contain the name
@@ -158,6 +163,8 @@ def lake_from_gdf(
         gdf = add_lakeno_to_gdf(gdf, boundname_column)
 
     for lakeno, lake_gdf in gdf.groupby("lakeno"):
+        if lake_gdf.index.duplicated().any():
+            lake_gdf = _aggregate_connections_per_cell(lake_gdf, ds)
         nlakeconn = lake_gdf.shape[0]
         if "strt" in lake_gdf:
             strt = _get_and_check_single_value(lake_gdf, "strt")
@@ -349,9 +356,38 @@ def lake_from_gdf(
     return lak
 
 
+def _aggregate_connections_per_cell(lake_gdf, ds):
+    """Combine multiple pieces of one lake within a grid cell into one connection.
+
+    A lake polygon commonly intersects a grid cell in more than one piece (e.g.
+    after nlmod.grid.gdf_to_grid). MODFLOW 6 applies each VERTICAL lake-GWF
+    connection over the full cell area, so per-piece rows would multiply-count the
+    exchange. Each piece therefore contributes conductance for its own area: the
+    combined bed resistance is clake = cell_area / sum(piece_area / clake), so
+    that the connection conductance cell_area / clake equals the summed piece
+    conductance — the same area-weighted aggregation nlmod.gwf.surface_water
+    .aggregate applies to RIV/DRN celldata. All other columns take the value of
+    the first piece per cell.
+    """
+    if "geometry" not in lake_gdf.columns or lake_gdf.geometry.isna().any():
+        raise ValueError(
+            "found multiple rows per cell for one lake; provide polygon "
+            "geometries so the pieces can be area-weighted into one connection"
+        )
+    cond = (lake_gdf.geometry.area / lake_gdf["clake"]).groupby(level=0).sum()
+    agg = lake_gdf.groupby(level=0).first()
+    agg["clake"] = ds["area"].data[agg.index] / cond
+    return agg
+
+
 def _get_and_check_single_value(lake_gdf, column):
     value = lake_gdf[column].iloc[0]
     if lake_gdf[column].isna().all() or lake_gdf[column].eq("").all():
+        return value
+    if pd.api.types.is_numeric_dtype(lake_gdf[column]):
+        # aggregated inputs (e.g. area-weighted stages) carry float-level noise
+        if not np.allclose(lake_gdf[column], value, rtol=1e-8, atol=0.0):
+            raise AssertionError(f"A single lake should have a single {column}")
         return value
     if not (lake_gdf[column] == value).all():
         raise (AssertionError(f"A single lake should have a single {column}"))

--- a/tests/test_013_surface_water.py
+++ b/tests/test_013_surface_water.py
@@ -4,7 +4,9 @@ import flopy
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pytest
 import util
+from shapely.geometry import box
 
 import nlmod
 
@@ -133,3 +135,82 @@ def test_aggregate():
         assert not celldata.isna().any(axis=None)
         riv_spd = nlmod.gwf.surface_water.build_spd(celldata, "RIV", ds)
         flopy.mf6.ModflowGwfriv(gwf, stress_period_data=riv_spd)
+
+
+def _get_lake_model(model_name):
+    model_ws = os.path.join(util.get_model_data_dir(), model_name)
+    ds = nlmod.get_ds(
+        [170000, 171000, 550000, 551000], model_ws=model_ws, model_name=model_name
+    )
+    ds = nlmod.time.set_ds_time(ds, time=[1], start=pd.Timestamp.today())
+    ds = nlmod.dims.refine(ds)
+
+    sim = nlmod.sim.sim(ds)
+    nlmod.sim.tdis(ds, sim)
+    nlmod.sim.ims(sim)
+    gwf = nlmod.gwf.gwf(ds, sim)
+    nlmod.gwf.dis(ds, gwf)
+    return ds, gwf
+
+
+def test_lake_from_gdf_aggregates_pieces_per_cell():
+    """Multiple pieces of a lake in one cell merge into a single connection.
+
+    A lake commonly intersects a grid cell in multiple polygon pieces (e.g. after
+    nlmod.grid.gdf_to_grid). Each piece should contribute conductance for its own
+    area, and the pieces should collapse to a single lake-GWF connection per cell,
+    like nlmod.gwf.surface_water.aggregate already does for RIV/DRN celldata.
+    """
+    ds, gwf = _get_lake_model("lp")
+
+    # lake_0 covers cell 14 with two pieces (6000 m2 at clake=10 and 2000 m2 at
+    # clake=20) and cell 15 with one piece (10000 m2, the full cell, at clake=10)
+    gdf_lake = gpd.GeoDataFrame(
+        {
+            "name": ["lake_0", "lake_0", "lake_0"],
+            "strt": [1.0, 1.0, 1.0],
+            "clake": [10.0, 20.0, 10.0],
+        },
+        geometry=[
+            box(0, 0, 100, 60),
+            box(0, 60, 50, 100),
+            box(100, 0, 200, 100),
+        ],
+        index=[14, 14, 15],
+    )
+
+    lak = nlmod.gwf.lake_from_gdf(gwf, gdf_lake, ds, boundname_column="name")
+
+    conns = lak.connectiondata.array
+    assert len(conns) == 2, "pieces within a cell should merge to one connection"
+    bedleak = {
+        cellid[-1]: bl
+        for (_, _, cellid, *_), bl in zip(
+            conns.tolist(), conns["bedleak"], strict=False
+        )
+    }
+    # bedleak * cell_area == sum(piece_area / clake), cell area is 10000 m2
+    assert bedleak[14] == pytest.approx((6000.0 / 10.0 + 2000.0 / 20.0) / 10000.0)
+    assert bedleak[15] == pytest.approx((10000.0 / 10.0) / 10000.0)
+    assert lak.packagedata.array[0][2] == 2  # nlakeconn counts cells, not pieces
+
+
+def test_lake_from_gdf_accepts_floating_point_strt_noise():
+    """Float-level noise in per-cell strt values is accepted as a single value.
+
+    Aggregated inputs (e.g. area-weighted stages per cell) carry float-level noise;
+    a single-value check with exact equality rejects them for no physical reason.
+    """
+    ds, gwf = _get_lake_model("ln")
+
+    gdf_lake = gpd.GeoDataFrame(
+        {
+            "name": ["lake_0", "lake_0"],
+            "strt": [1.0, 1.0 + 1e-12],
+            "clake": [10.0, 10.0],
+        },
+        index=[14, 15],
+    )
+
+    lak = nlmod.gwf.lake_from_gdf(gwf, gdf_lake, ds, boundname_column="name")
+    assert lak.packagedata.array[0][1] == pytest.approx(1.0)


### PR DESCRIPTION
## What

`lake_from_gdf` now accepts per-piece input — multiple rows per cellid for one lake, as produced directly by `nlmod.grid.gdf_to_grid` — and combines the pieces into one lake-GWF connection per cell with an area-weighted bed resistance. It also tolerates float-level noise in numeric per-lake settings.

## Why

Two defects when the input is not pre-aggregated by the caller:

1. **Per-piece rows multiply-count the lake-aquifer exchange.** MODFLOW 6 applies each VERTICAL lake-GWF connection over the **full cell area**, and `lake_from_gdf` turns every row into its own connection with `bedleak = 1/clake`. A cell holding two pieces of one lake (6000 m² at `clake=10` and 2000 m² at `clake=20` in a 10000 m² cell) gets two full-cell-area connections totalling `0.15 * cell_area` of conductance, where the pieces physically justify `(6000/10 + 2000/20) / 10000 = 0.07 * cell_area`.
2. **Exact-equality single-value check rejects aggregated inputs.** `_get_and_check_single_value` compares `strt` (and outlet settings) with `==`. Area-weighted per-cell stages carry float-level noise (a 1e-12 difference), which raised `AssertionError: A single lake should have a single strt` for no physical reason.

RIV and DRN already have exactly this aggregation step in nlmod: `nlmod.gwf.surface_water.aggregate` collapses per-piece celldata to one reach per cell with area-weighted parameters before `build_spd`. The LAK path lacked the equivalent, forcing every caller to hand-roll it. (Encountered wiring the NHFLO Bergen ponds — NHFLO/models#127, NHFLO/tools#58 — where the workaround currently lives downstream.)

## How

- New `_aggregate_connections_per_cell(lake_gdf, ds)`, invoked per lake when the cellid index has duplicates: combined `clake = cell_area / sum(piece_area / clake)`, so the VERTICAL connection conductance `cell_area / clake` equals the summed piece conductance; other columns take the first piece's value (they are per-lake settings, still validated by `_get_and_check_single_value`). Raises a clear `ValueError` when pieces come without geometry, since the areas are then unknown.
- `_get_and_check_single_value` uses `np.allclose(rtol=1e-8, atol=0)` for numeric columns; exact comparison is kept for strings (boundnames, timeseries names, `lakeout`).
- `nlakeconn` consequently counts cells, not pieces.

Behaviour for already-aggregated input (one row per cell per lake) is unchanged.

## Tests

Two regression tests in `test_013_surface_water.py`, both shown to fail on unchanged `dev` before the fix:

- `test_lake_from_gdf_aggregates_pieces_per_cell` — fails on dev with 3 connections at `bedleak=0.1`/`0.05` instead of 2 connections at the area-weighted `0.07`/`0.1`; also pins `nlakeconn == 2`.
- `test_lake_from_gdf_accepts_floating_point_strt_noise` — fails on dev with the `AssertionError` on a `1e-12` strt difference.

`test_gdf_lake` (existing) still passes; `ruff check`/`ruff format` add no findings relative to dev.
