### PR TITLE
allow missing layer definitions in combine_layers:

### DIFF
--- a/docs/utilities/04_modifying_layermodels.ipynb
+++ b/docs/utilities/04_modifying_layermodels.ipynb
@@ -289,10 +289,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "combine_layers = [\n",
-    "    tuple(np.argwhere(regis.layer.str.startswith(\"URz\").data).squeeze().tolist()),\n",
-    "    tuple(np.argwhere(regis.layer.isin([\"PZWAz2\", \"PZWAz3\"]).data).squeeze().tolist()),\n",
-    "]\n",
+    "combine_layers = {\n",
+    "    \"URz1\": [\"URz1\", \"URz2\", \"URz3\", \"URz4\", \"URz5\"],\n",
+    "    \"PZWAz2\": [\"PZWAz2\", \"PZWAz3\"],\n",
+    "}\n",
     "combine_layers"
    ]
   },
@@ -465,8 +465,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "nlmod (3.13.11)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -676,6 +676,25 @@ def combine_layers_ds(
     if isinstance(combine_layers, dict):
         # remove single layer entries if they exist:
         combine_layers = {k: v for k, v in combine_layers.items() if len(v) > 1}
+        # remove missing layers
+        for k, v in combine_layers.items():
+            missing = []
+            for i in v:
+                if i not in ds.layer:
+                    missing.append(i)
+            if len(missing) > 0:
+                logger.warning(
+                    "Layer(s) %s not found in dataset, will be "
+                    "removed from combine_layers.",
+                    missing,
+                )
+                # Preserve original layer order while removing missing entries.
+                combine_layers[k] = [i for i in v if i not in missing]
+
+        # Groups can become empty or single-layer after removing missing layers.
+        # Keep only true merge groups to avoid reindex/name mismatches downstream.
+        combine_layers = {k: v for k, v in combine_layers.items() if len(v) > 1}
+
         new_layer_names = combine_layers.keys()
         combine_layers_integer = [
             tuple(np.where(ds.layer.isin(x))[0]) if isinstance(x[0], str) else x

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -675,7 +675,8 @@ def combine_layers_ds(
 
     if isinstance(combine_layers, dict):
         # remove single layer entries if they exist:
-        combine_layers = {k: v for k, v in combine_layers.items() if len(v) > 1}
+        combine_layers = {k: v for k, v in combine_layers.items()}
+        rename_layers = {v[0]: k for k, v in combine_layers.items() if len(v) == 1}
         # remove missing layers
         for k, v in combine_layers.items():
             missing = []
@@ -703,6 +704,7 @@ def combine_layers_ds(
     else:
         # remove single layer entries if they exist:
         combine_layers = [x for x in combine_layers if len(x) > 1]
+        rename_layers = None
         combine_layers_integer = [
             tuple(np.where(ds.layer.isin(x))[0]) if isinstance(x[0], str) else x
             for x in combine_layers
@@ -779,6 +781,11 @@ def combine_layers_ds(
 
     # remove layer dimension from top
     ds_combine = remove_layer_dim_from_top(ds_combine, inconsistency_threshold=0.001)
+
+    if rename_layers is not None:
+        ds_combine = ds_combine.assign_coords(
+            layer=[rename_layers.get(lay, lay) for lay in ds_combine["layer"].data]
+        )
 
     if return_reindexer:
         return ds_combine, reindexer


### PR DESCRIPTION
- makes it easier to get consistent mappings across multiple extents, just use the mapping for largest extent for the smallest extent and automatically discard missing layers.